### PR TITLE
chore: bump version to 4.1.1 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.1] - 2026-03-22
+
+### 🐛 Bug Fixes
+* **Consumer:** Previene memory leak al detener el `TimerTask` de health check previo antes de realizar una reconexiÃ³n.
+* **Controller:** Corrige la mutaciÃ³n accidental de \`log_tags\` globales al usar una lÃ³gica de herencia no destructiva en \`compute_tags\`.
+
+### ✨ Improvements
+* **Controller:** Ahora lanza una excepciÃ³n \`BugBunny::BadRequest\` (400) si el cuerpo de la peticiÃ³n contiene un JSON invÃ¡lido, mejorando la depuraciÃ³n en el cliente.
+* **Resource:** Se aÃ±adiÃ³ una protecciÃ³n a \`.with\` (\`ScopeProxy\`) para asegurar que el contexto sea de un solo uso, evitando efectos secundarios en llamadas encadenadas.
+
 ## [4.1.0] - 2026-03-22
 
 ### 🚀 New Features & Improvements

--- a/lib/bug_bunny/consumer.rb
+++ b/lib/bug_bunny/consumer.rb
@@ -44,6 +44,7 @@ module BugBunny
     # @param connection [Bunny::Session] Conexión nativa de Bunny.
     def initialize(connection)
       @session = BugBunny::Session.new(connection)
+      @health_timer = nil
     end
 
     # Inicia la suscripción a la cola y comienza el bucle de procesamiento.
@@ -244,12 +245,16 @@ module BugBunny
     # @param q_name [String] Nombre de la cola a monitorear.
     # @return [void]
     def start_health_check(q_name)
+      # Detener el timer anterior antes de crear uno nuevo (evita leak en cada retry)
+      @health_timer&.shutdown
+      @health_timer = nil
+
       file_path = BugBunny.configuration.health_check_file
 
       # Toque inicial para indicar al orquestador que el worker arrancó correctamente
       touch_health_file(file_path) if file_path
 
-      Concurrent::TimerTask.new(execution_interval: BugBunny.configuration.health_check_interval) do
+      @health_timer = Concurrent::TimerTask.new(execution_interval: BugBunny.configuration.health_check_interval) do
         # 1. Verificamos la salud de RabbitMQ (si falla, levanta un error y corta la ejecución del bloque)
         session.channel.queue_declare(q_name, passive: true)
 
@@ -258,7 +263,8 @@ module BugBunny
       rescue StandardError => e
         BugBunny.configuration.logger.warn("[BugBunny::Consumer] ⚠️  Queue check failed: #{e.message}. Reconnecting session...")
         session.close
-      end.execute
+      end
+      @health_timer.execute
     end
 
     # Actualiza la fecha de modificación del archivo de health check (touchfile).

--- a/lib/bug_bunny/controller.rb
+++ b/lib/bug_bunny/controller.rb
@@ -146,11 +146,6 @@ module BugBunny
     def process(body)
       prepare_params(body)
 
-      # Inyección de configuración global de logs si el controlador no define propios
-      if self.class.log_tags.empty? && BugBunny.configuration.log_tags.any?
-        self.class.log_tags = BugBunny.configuration.log_tags
-      end
-
       action_name = headers[:action].to_sym
       current_arounds = resolve_callbacks(self.class.around_actions, action_name)
 
@@ -245,12 +240,11 @@ module BugBunny
       if body.is_a?(Hash)
         params.merge!(body)
       elsif body.is_a?(String) && headers[:content_type].to_s.include?('json')
-        parsed = begin
-                   JSON.parse(body)
-                 rescue JSON::ParserError
-                   nil
-                 end
-        params.merge!(parsed) if parsed
+        begin
+          params.merge!(JSON.parse(body))
+        rescue JSON::ParserError => e
+          raise BugBunny::BadRequest, "Invalid JSON in request body: #{e.message}"
+        end
       else
         self.raw_string = body
       end
@@ -284,7 +278,8 @@ module BugBunny
     end
 
     def compute_tags
-      self.class.log_tags.map do |tag|
+      tags = self.class.log_tags.presence || BugBunny.configuration.log_tags
+      tags.map do |tag|
         case tag
         when Proc
           tag.call(self)

--- a/lib/bug_bunny/resource.rb
+++ b/lib/bug_bunny/resource.rb
@@ -154,9 +154,24 @@ module BugBunny
       end
 
       # Proxy para el encadenamiento del método `.with`.
+      # Solo puede usarse para UNA llamada de método: el contexto se restaura al finalizar.
       class ScopeProxy < BasicObject
-        def initialize(target, keys, old_values); @target = target; @keys = keys; @old_values = old_values; end
-        def method_missing(method, *args, &block); @target.public_send(method, *args, &block); ensure; @keys.each { |k, v| ::Thread.current[v] = @old_values[k] }; end
+        def initialize(target, keys, old_values)
+          @target = target
+          @keys = keys
+          @old_values = old_values
+          @used = false
+        end
+
+        def method_missing(method, *args, &block)
+          if @used
+            ::Kernel.raise ::BugBunny::Error, "ScopeProxy is single-use. Call .with again for a new context."
+          end
+          @used = true
+          @target.public_send(method, *args, &block)
+        ensure
+          @keys.each { |k, v| ::Thread.current[v] = @old_values[k] }
+        end
       end
 
       # Calcula la routing key final.

--- a/lib/bug_bunny/version.rb
+++ b/lib/bug_bunny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BugBunny
-  VERSION = "4.1.0"
+  VERSION = "4.1.1"
 end


### PR DESCRIPTION
Bump version to 4.1.1 and update CHANGELOG.md with recent fixes for Consumer memory leak, Controller JSON validation and Resource ScopeProxy protection.