### PR TITLE
feat: align observability with exis_ray standards v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [4.3.0] - 2026-03-24
+
+### 📈 Observability Alignment (ExisRay Standards)
+* **Monotonic Clock Durations:** Implementación de `Process.clock_gettime(Process::CLOCK_MONOTONIC)` para calcular todas las duraciones técnicas y de negocio (`duration_s`), garantizando precisión en entornos Cloud.
+* **Unit-Suffix Keys (Data First):** Se renombraron las llaves de logs para incluir explícitamente su unidad:
+    * `timeout` -> `timeout_s`
+    * `retry_in` -> `retry_in_s`
+    * `attempt` -> `attempt_count`
+    * `max_attempts` -> `max_attempts_count`
+* **Error Field Standardization:** Se renombraron todos los campos `error` a `error_message` para ser consistentes con los eventos de falla de `exis_ray`.
+* **Automatic Field Removal:** Se eliminó la inyección manual de `source` delegando la responsabilidad a la gema `exis_ray`.
+
 ## [4.2.0] - 2026-03-22
 
 ### ðŸ”  Observability & Structured Logging

--- a/lib/bug_bunny/consumer.rb
+++ b/lib/bug_bunny/consumer.rb
@@ -100,7 +100,7 @@ module BugBunny
         max_attempts = BugBunny.configuration.max_reconnect_attempts
 
         if max_attempts && attempt >= max_attempts
-          BugBunny.configuration.logger.error { "component=bug_bunny event=reconnect_exhausted attempts=#{max_attempts} error=#{e.message.inspect}" }
+          BugBunny.configuration.logger.error { "component=bug_bunny event=reconnect_exhausted max_attempts_count=#{max_attempts} error_message=#{e.message.inspect}" }
           raise
         end
 
@@ -109,7 +109,7 @@ module BugBunny
           BugBunny.configuration.max_reconnect_interval
         ].min
 
-        BugBunny.configuration.logger.error { "component=bug_bunny event=connection_error error=#{e.message.inspect} attempt=#{attempt} max_attempts=#{max_attempts || 'infinity'} retry_in=#{wait}" }
+        BugBunny.configuration.logger.error { "component=bug_bunny event=connection_error error_message=#{e.message.inspect} attempt_count=#{attempt} max_attempts_count=#{max_attempts || 'infinity'} retry_in_s=#{wait}" }
         sleep wait
         retry
       end
@@ -126,6 +126,8 @@ module BugBunny
     # @param body [String] El payload crudo del mensaje.
     # @return [void]
     def process_message(delivery_info, properties, body)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
       # 1. Validación de Headers (URL path)
       path = properties.type || (properties.headers && properties.headers['path'])
 
@@ -215,8 +217,12 @@ module BugBunny
 
       session.channel.ack(delivery_info.delivery_tag)
 
+      duration_s = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(6)
+      BugBunny.configuration.logger.info("component=bug_bunny event=message_processed status=#{response_payload[:status]} duration_s=#{duration_s} controller=#{controller_class_name} action=#{route_info[:action]}")
+
     rescue StandardError => e
-      BugBunny.configuration.logger.error { "component=bug_bunny event=execution_error error_class=#{e.class} error=#{e.message.inspect}" }
+      duration_s = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(6)
+      BugBunny.configuration.logger.error { "component=bug_bunny event=execution_error error_class=#{e.class} error_message=#{e.message.inspect} duration_s=#{duration_s}" }
       BugBunny.configuration.logger.debug { "component=bug_bunny event=execution_error backtrace=#{e.backtrace.first(5).join(' | ').inspect}" }
       handle_fatal_error(properties, 500, "Internal Server Error", e.message)
       session.channel.reject(delivery_info.delivery_tag, false)
@@ -278,7 +284,7 @@ module BugBunny
         # 2. Si llegamos aquí, RabbitMQ y la cola están vivos. Avisamos al orquestador actualizando el archivo.
         touch_health_file(file_path) if file_path
       rescue StandardError => e
-        BugBunny.configuration.logger.warn("component=bug_bunny event=health_check_failed queue=#{q_name} error=#{e.message.inspect}")
+        BugBunny.configuration.logger.warn("component=bug_bunny event=health_check_failed queue=#{q_name} error_message=#{e.message.inspect}")
         session.close
       end
       @health_timer.execute
@@ -293,7 +299,7 @@ module BugBunny
     def touch_health_file(file_path)
       FileUtils.touch(file_path)
     rescue StandardError => e
-      BugBunny.configuration.logger.error("component=bug_bunny event=health_check_file_error path=#{file_path} error=#{e.message.inspect}")
+      BugBunny.configuration.logger.error("component=bug_bunny event=health_check_file_error path=#{file_path} error_message=#{e.message.inspect}")
     end
   end
 end

--- a/lib/bug_bunny/controller.rb
+++ b/lib/bug_bunny/controller.rb
@@ -204,7 +204,7 @@ module BugBunny
       end
 
       # Fallback genérico si la excepción no fue mapeada
-      BugBunny.configuration.logger.error { "component=bug_bunny event=unhandled_exception error_class=#{exception.class} error=#{exception.message.inspect}" }
+      BugBunny.configuration.logger.error { "component=bug_bunny event=unhandled_exception error_class=#{exception.class} error_message=#{exception.message.inspect}" }
       BugBunny.configuration.logger.error { "component=bug_bunny event=unhandled_exception backtrace=#{exception.backtrace.first(5).join(' | ').inspect}" }
 
       {

--- a/lib/bug_bunny/producer.rb
+++ b/lib/bug_bunny/producer.rb
@@ -73,7 +73,7 @@ module BugBunny
       begin
         fire(request)
 
-        BugBunny.configuration.logger.debug { "component=bug_bunny event=rpc_waiting correlation_id=#{cid} timeout=#{wait_timeout}" }
+        BugBunny.configuration.logger.debug { "component=bug_bunny event=rpc_waiting correlation_id=#{cid} timeout_s=#{wait_timeout}" }
 
         # Bloqueamos el hilo aquí hasta que llegue la respuesta o expire el timeout
         response_payload = future.value(wait_timeout)

--- a/lib/bug_bunny/session.rb
+++ b/lib/bug_bunny/session.rb
@@ -128,7 +128,7 @@ module BugBunny
       BugBunny.configuration.logger.warn('component=bug_bunny event=reconnect_attempt')
       @connection.start
     rescue StandardError => e
-      BugBunny.configuration.logger.error { "component=bug_bunny event=reconnect_failed error=#{e.message.inspect}" }
+      BugBunny.configuration.logger.error { "component=bug_bunny event=reconnect_failed error_message=#{e.message.inspect}" }
       raise BugBunny::CommunicationError, "Could not reconnect to RabbitMQ: #{e.message}"
     end
   end

--- a/lib/bug_bunny/version.rb
+++ b/lib/bug_bunny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BugBunny
-  VERSION = "4.2.0"
+  VERSION = "4.3.0"
 end


### PR DESCRIPTION
Bump version to 4.3.0 Minor release. This PR aligns all logging with the latest ExisRay standards:
- **Monotonic Clock**: Use `Process.clock_gettime(Process::CLOCK_MONOTONIC)` for all durations (`duration_s`).
- **Unit-Suffix Keys**: Renamed keys to include their unit (`_s`, `_count`).
- **Error Fields**: Unified to `error_message`.
- **Automatic Fields**: Removed `source` (handled by exis_ray).