### PR TITLE
test(integration): fix transient_nonexcl_queues en helpers (parte A de #40)

### DIFF
--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -2,6 +2,12 @@
 
 require 'timeout'
 
+# Queue options usados por los workers de integración. \`exclusive: true\` evita
+# la deprecación de \`transient_nonexcl_queues\` en RabbitMQ 4.x — la queue queda
+# ligada a la conexión del worker y desaparece automáticamente al cerrarla.
+# Sobreescribe la cascada de \`BugBunny.configuration.queue_options\`.
+TEST_WORKER_QUEUE_OPTS = { exclusive: true, durable: false, auto_delete: true }.freeze unless defined?(TEST_WORKER_QUEUE_OPTS)
+
 # Helpers compartidos para specs de integración con RabbitMQ real.
 # Incluido automáticamente en todos los specs marcados con :integration.
 RSpec.shared_context 'integration helpers' do
@@ -31,6 +37,7 @@ RSpec.shared_context 'integration helpers' do
         exchange_name: exchange,
         exchange_type: exchange_type,
         routing_key:   routing_key,
+        queue_opts:    TEST_WORKER_QUEUE_OPTS,
         block:         true
       )
     rescue StandardError => e
@@ -57,7 +64,7 @@ RSpec.shared_context 'integration helpers' do
     worker_thread = Thread.new do
       ch = conn.create_channel
       x  = ch.public_send(exchange_type, exchange, BugBunny.configuration.exchange_options)
-      q  = ch.queue(queue, BugBunny.configuration.queue_options)
+      q  = ch.queue(queue, TEST_WORKER_QUEUE_OPTS)
       q.bind(x, routing_key: routing_key)
       q.subscribe(block: true) do |delivery, props, body|
         messages << { body: body, routing_key: delivery.routing_key, headers: props.headers }


### PR DESCRIPTION
Refs #40 (parte A).

## Summary

Los helpers de integration (\`with_spy_worker\`, \`with_running_worker\`) declaraban queues con \`BugBunny.configuration.queue_options\` que defaultea a \`{ exclusive: false, durable: false, auto_delete: true }\` — la combo \`transient_nonexcl_queues\` que RabbitMQ 4.x deprecó. Como resultado, **24 specs en \`client_spec\`, \`consumer_middleware_spec\` y \`resource_spec\` rompían el broker al intentar declarar la queue**.

Fix: nueva constante \`TEST_WORKER_QUEUE_OPTS = { exclusive: true, durable: false, auto_delete: true }\` que sobrescribe la config global solo en los helpers. La queue queda ligada a la conexión del worker (que es lo que queremos en un spec: efímera y limpia al final).

## Scope

**Parte A de #40 — fix solo de tests.** No toca \`BugBunny::Session::DEFAULT_QUEUE_OPTIONS\` ni la config global de la gema.

El default productivo **también está afectado** por la misma deprecación cuando se corre contra RMQ 4.x — \`Consumer#subscribe\` sin override explícito declara queues con la combo deprecada. Eso merece su propia discusión (semi-breaking, decisión de producto) → próximo issue.

## Test plan

- [x] \`bundle exec rspec spec/integration/\` → **44 examples, 0 failures**
- [x] \`bundle exec rspec spec/unit/\` → 206 examples, 0 failures
- [x] Previo a este PR: \`client_spec\`, \`consumer_middleware_spec\`, \`resource_spec\` fallaban con \`INTERNAL_ERROR - Feature transient_nonexcl_queues is deprecated\`. Ahora pasan.

## Métricas

- 1 archivo tocado: \`spec/support/integration_helper.rb\`
- +8 / -1 LOC
- Zero impacto en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)