### PR TITLE
docs: cobertura return_raise + PublishUnroutable + nuevos defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,13 @@ BugBunny.configure do |config|
   # Health check file for Kubernetes / Docker Swarm liveness probes
   config.health_check_file = '/tmp/bug_bunny_health'
 
+  # Publisher Confirms — fail-loud defaults (both flags default to true).
+  # Set to false to restore legacy log-only behavior.
+  config.nack_raise   = true   # broker NACK → raise BugBunny::PublishNacked
+  config.return_raise = true   # broker basic.return (mandatory) → raise BugBunny::PublishUnroutable
+
   # Callback invoked when the broker returns an unroutable mandatory message.
+  # Runs BEFORE PublishUnroutable is raised (if return_raise is true).
   # When nil (default), BugBunny logs the return as `session.broker_return` at :warn.
   # Signature: ->(return_info, properties, body) { ... }
   config.on_return = ->(return_info, _props, body) {
@@ -224,11 +230,26 @@ client.publish('acct.start',
 | `confirmed` | Boolean | `false` | Block until `wait_for_confirms` returns. |
 | `mandatory` | Boolean | `false` | Broker returns the message if it cannot be routed to any queue. Requires `confirmed: true` to be useful. |
 | `confirm_timeout` | Float | `nil` | Seconds to wait for the broker ACK. Raises `BugBunny::RequestTimeout` if exceeded. |
-| `nack_raise` | Boolean | `nil` | Per-request override of `config.nack_raise`. When `nil`, falls back to the global flag. |
+| `nack_raise` | Boolean | `nil` | Per-request override of `config.nack_raise`. When `nil`, falls back to the global flag (default `true`). |
+| `return_raise` | Boolean | `nil` | Per-request override of `config.return_raise`. When `nil`, falls back to the global flag (default `true`). Requires `confirmed: true` and `mandatory: true` to take effect. |
 
-If the broker NACKs the publish (explicit rejection — disk full, internal confirm policy, etc.), the call raises `BugBunny::PublishNacked` by default. The exception exposes `path` and `nacked_count`. Critical publishers (audit, billing, RADIUS accounting) can let it bubble up to translate into HTTP 5xx so upstream systems retry. To restore the legacy "log-only" behaviour, set `BugBunny.configuration.nack_raise = false` globally or pass `nack_raise: false` per request.
+**Two broker signals, two exceptions:**
 
-Unroutable returned messages are handled by a single global callback (see `config.on_return` below). The default handler logs them as `session.broker_return` at `warn` level — nothing is dropped silently.
+| Broker signal | Default behavior | Exception class | Fields |
+|---|---|---|---|
+| `basic.nack` (explicit rejection) | Raises | `BugBunny::PublishNacked` | `path`, `nacked_count` |
+| `basic.return` (unroutable + `mandatory: true`) | Raises | `BugBunny::PublishUnroutable` | `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id` |
+
+Both exceptions translate naturally into HTTP 5xx in critical publishers (audit, billing, RADIUS accounting) so upstream systems retry. The `config.on_return` callback (if defined) still runs before `PublishUnroutable` is raised — useful for alerting/metrics. To restore the legacy "log-only" behaviour:
+
+```ruby
+BugBunny.configure do |c|
+  c.nack_raise   = false  # or pass `nack_raise: false` per request
+  c.return_raise = false  # or pass `return_raise: false` per request
+end
+```
+
+When `mandatory: false` (the default), `return_raise` is inert — the broker never emits `basic.return` without mandatory.
 
 ---
 
@@ -289,9 +310,15 @@ BugBunny maps RabbitMQ responses to a semantic exception hierarchy, similar to h
 
 ```
 BugBunny::Error
+├── CommunicationError                  (network / channel failure)
+├── ConfigurationError                  (invalid config attribute)
+├── SecurityError                       (unauthorized controller resolution)
+├── PublishNacked                       (broker basic.nack on :confirmed publish)
+├── PublishUnroutable                   (broker basic.return on mandatory + :confirmed)
 ├── ClientError (4xx)
 │   ├── BadRequest (400)
 │   ├── NotFound (404)
+│   │   └── RoutingError                (consumer-side: no route for verb + path)
 │   ├── NotAcceptable (406)
 │   ├── RequestTimeout (408)
 │   ├── Conflict (409)

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -15,7 +15,9 @@ Skill de conocimiento completo sobre BugBunny. Consultame para cualquier pregunt
 **Session** — `BugBunny::Session` envuelve canales de Bunny con thread-safety y double-checked locking.
 **RPC** — Patrón síncrono que usa la pseudo-cola `amq.rabbitmq.reply-to` para respuestas sin crear queues temporales.
 **Fire-and-Forget** — Patrón asíncrono donde el producer publica y continúa sin esperar respuesta. Retorna `{ 'status' => 202 }`.
-**Publisher Confirms** — Extensión de RabbitMQ que confirma al publisher que el broker recibió el mensaje. BugBunny lo expone como `confirmed: true` en `Client#publish`: el publish bloquea hasta `wait_for_confirms`. NACK del broker (rechazo explícito) levanta `BugBunny::PublishNacked` por default; configurable via `config.nack_raise = false` o `nack_raise: false` per request para volver al modo log-only.
+**Publisher Confirms** — Extensión de RabbitMQ que confirma al publisher que el broker recibió el mensaje. BugBunny lo expone como `confirmed: true` en `Client#publish`: el publish bloquea hasta `wait_for_confirms`. Dos señales asíncronas del broker, ambas convertidas en excepciones raise-eables en el publish thread:
+- **NACK** (rechazo explícito) → `BugBunny::PublishNacked` (configurable via `config.nack_raise = false`).
+- **basic.return** (mandatory unroutable) → `BugBunny::PublishUnroutable` (configurable via `config.return_raise = false`).
 **Mandatory** — Flag de `basic.publish` que pide al broker retornar el mensaje al publisher si no es ruteable a ninguna cola. Se procesa via `basic.return` (no es respuesta del request).
 **basic.return** — Evento asincrónico que Bunny dispatcha por exchange (`Bunny::Exchange#on_return`). BugBunny registra un handler único por nombre de exchange al resolverlo en `Session#exchange` y lo delega a `Configuration#on_return` o al default que logea.
 **Resource** — ORM tipo ActiveRecord que mapea operaciones CRUD a llamadas AMQP.
@@ -109,6 +111,8 @@ BugBunny mide y emite duraciones automáticamente. **No envolver llamadas a `cli
 | `producer.published` | INFO | `Producer#publish_message` (post) | `method`, `path`, `routing_key`, `messaging_message_id`, **`duration_s`** (publish solo) |
 | `producer.confirmed` | INFO | `Producer#confirmed` (post-ACK) | `method`, `path`, `routing_key`, **`publish_duration_s`**, **`confirm_duration_s`**, **`duration_s`** (total) |
 | `producer.confirms_nacked` | WARN | `Producer#confirmed` (NACK) | `count`, `path` |
+| `producer.publish_unroutable` | WARN | `Producer#confirmed` (basic.return) | `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `messaging_message_id` |
+| `client.return_raise_ignored` | WARN | `Client#publish` | `delivery_mode`, `mandatory` (cuando `return_raise:true` se pasa sin prereqs) |
 | `producer.rpc_waiting` | DEBUG | `Producer#rpc` | `messaging_message_id`, `timeout_s` |
 | `producer.rpc_response_received` | INFO | `Producer#rpc` (reply recibido) | `method`, `path`, **`duration_s`** (round-trip total), `response_body` |
 | `producer.rpc_response_orphaned` | WARN | reply listener | `correlation_id` |
@@ -160,8 +164,14 @@ BugBunny.configure do |config|
   config.rpc_reply_headers = -> { { 'X-Trace-Id' => Tracer.id } }
   config.on_rpc_reply = ->(h) { Tracer.hydrate(h['X-Trace-Id']) }
 
-  # Publisher Confirms — handler global para basic.return (mensajes mandatory no ruteados).
-  # Si es nil, BugBunny logea como `session.broker_return` con nivel :warn.
+  # Publisher Confirms — fail-loud por default (ambos true).
+  # Setear false para volver al comportamiento legacy "log y retorna 202".
+  config.nack_raise   = true   # NACK → raise BugBunny::PublishNacked
+  config.return_raise = true   # basic.return (mandatory) → raise BugBunny::PublishUnroutable
+
+  # Callback global para basic.return. Corre ANTES del raise PublishUnroutable
+  # cuando return_raise es true. Si on_return es nil, BugBunny logea
+  # `session.broker_return` con nivel :warn.
   # Firma: ->(return_info, properties, body)
   config.on_return = ->(ri, _props, body) { MyAlerts.unroutable(rk: ri.routing_key, body: body) }
 
@@ -233,11 +243,32 @@ client.publish('events', method: :post, body: { type: 'order.placed' })
 client.publish('acct.start', exchange: 'acct_x', body: payload,
                confirmed: true, mandatory: true, confirm_timeout: 0.5)
 # → { 'status' => 202, 'body' => nil }   # broker ACK confirmado
-# Si broker NACK: logea `producer.confirms_nacked` y raise BugBunny::PublishNacked
-#   (default — opt-out con config.nack_raise = false o nack_raise: false per request).
-# Si timeout: raise BugBunny::RequestTimeout.
-# Si mandatory + no ruteable: dispara `Configuration#on_return` (default: logea `session.broker_return`).
 ```
+
+**Dos señales del broker, dos excepciones simétricas:**
+
+| Señal | Default | Excepción | Campos |
+|---|---|---|---|
+| `basic.nack` | raise | `BugBunny::PublishNacked` | `path`, `nacked_count` |
+| `basic.return` (mandatory unrouted) | raise | `BugBunny::PublishUnroutable` | `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id` |
+
+```ruby
+# Comportamiento default (4.13+ para nack_raise, 4.15+ para return_raise):
+#   broker NACK → PublishNacked
+#   mandatory + unroutable → on_return callback (si está) → PublishUnroutable
+#   timeout en wait_for_confirms → RequestTimeout
+#
+# Opt-out (modo "log + 202 silencioso"):
+config.nack_raise   = false  # o per-request: nack_raise: false
+config.return_raise = false  # o per-request: return_raise: false
+
+# Override per-request gana sobre config global:
+client.publish('foo', confirmed: true, mandatory: true, return_raise: false, body: {})
+```
+
+**Bridge cross-thread interno (basic.return):** `basic.return` viaja en el reader thread de Bunny (asíncrono). Para hacer `PublishUnroutable` raise-able en el publish thread, BugBunny mantiene un `Session#@pending_returns = Concurrent::Map` correlacionado por `correlation_id`. `Producer#confirmed` auto-asigna `correlation_id` (UUID v4) si falta, registra un `Concurrent::Event` antes del publish, y tras `wait_for_confirms` true espera `RETURN_RACE_WINDOW_S` (50ms) para tolerar GVL scheduling — AMQP garantiza orden wire `return → ack`. El `on_return` user callback se invoca igual antes del raise (orden: signal event → user_cb → raise), así una excepción en el callback no impide el raise.
+
+**Inert cases:** `return_raise: true` sin `mandatory: true` o sin `confirmed: true` emite `client.return_raise_ignored` (WARN) y se ignora — el flag requiere ambos prereqs.
 
 `Bunny::Channel#wait_for_confirms` no soporta timeout nativo en Bunny 2.x. BugBunny lo implementa lanzando la espera en un hilo auxiliar y usando `Concurrent::IVar#value(timeout)` como reloj.
 

--- a/skill/references/client-middleware.md
+++ b/skill/references/client-middleware.md
@@ -72,7 +72,7 @@ El `Producer` es usado internamente por el `Client`. Implementa tres patrones de
 - Publica y bloquea hasta `channel.wait_for_confirms` del broker.
 - Bunny 2.x **no soporta timeout** nativo en `wait_for_confirms` — BugBunny envuelve la llamada en un hilo auxiliar y usa `Concurrent::IVar#value(timeout)` como reloj. Si `confirm_timeout` expira → `BugBunny::RequestTimeout`.
 - Si `wait_for_confirms` devuelve `false` (broker NACKea), se logea `producer.confirms_nacked` con `count` y `path`. Por default (`config.nack_raise = true`) levanta `BugBunny::PublishNacked` con `path` y `nacked_count`. Para opt-out: `config.nack_raise = false` o pasar `nack_raise: false` per request — en ese caso solo logea y retorna 202.
-- Si `mandatory: true` y el mensaje no es ruteable, el broker dispara `basic.return`. El handler se atacha vía `Bunny::Exchange#on_return` en `Session#exchange` la primera vez que se resuelve cada exchange (cacheado por nombre, una sola vez por canal) y delega a `Configuration#on_return` o al logger por default.
+- Si `mandatory: true` y el mensaje no es ruteable, el broker dispara `basic.return`. El handler se atacha vía `Bunny::Exchange#on_return` en `Session#exchange` la primera vez que se resuelve cada exchange (cacheado por nombre, una sola vez por canal) y delega a `Configuration#on_return` o al logger por default. **Por default (`config.return_raise = true`)** además levanta `BugBunny::PublishUnroutable` en el publish thread con `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id`. Para opt-out: `config.return_raise = false` o pasar `return_raise: false` per request — solo logea/invoca callback y retorna 202.
 - Errores del canal se envuelven en `BugBunny::CommunicationError`; errores `BugBunny::Error` pre-existentes se propagan sin envolver.
 - **Emite `producer.confirmed` (INFO) con tres duraciones desglosadas**: `publish_duration_s` (TCP enqueue), `confirm_duration_s` (`wait_for_confirms`), `duration_s` (total). Útil para distinguir latencia de red vs latencia de confirm policy del broker.
 
@@ -183,18 +183,35 @@ client.publish('x', confirmed: true, mandatory: true)
    ▼
 Producer#confirmed
    │
-   ├──> publish_message     (exchange.publish con mandatory: true)
+   ├──> setup_return_listener  (si return_raise? → Session#register_return_listener(cid))
+   │                            │
+   │                            └─ @session.@pending_returns[cid] = { event:, info: nil }
    │
-   ├──> wait_for_confirms!  (espera ACK del broker, con timeout opcional)
+   ├──> publish_message         (exchange.publish con mandatory: true, correlation_id auto-asignado)
    │
-   └──> handle_confirm_result
-            ├─ acked == true  → return { status: 202 }
-            └─ acked == false → log WARN producer.confirms_nacked
-                                  └─ raise BugBunny::PublishNacked  (si config.nack_raise || req.nack_raise)
+   ├──> wait_for_confirms!      (espera ACK del broker, con timeout opcional)
+   │
+   ├──> handle_confirm_result
+   │        ├─ acked == true  → continúa
+   │        └─ acked == false → log WARN producer.confirms_nacked
+   │                              └─ raise BugBunny::PublishNacked  (si config.nack_raise || req.nack_raise)
+   │
+   ├──> handle_return_result    (si listener registrado)
+   │        ├─ slot.event.wait(RETURN_RACE_WINDOW_S = 0.05)
+   │        ├─ slot.info == nil → return (ack normal sin return)
+   │        └─ slot.info != nil → log WARN producer.publish_unroutable
+   │                                └─ raise BugBunny::PublishUnroutable
+   │
+   └──> ensure: teardown_return_listener (Session#unregister_return_listener(cid))
 
-Asíncronamente, si el broker no pudo rutear:
-   broker ──basic.return──> Exchange#on_return ──> Session handler ──> Configuration#on_return
-                                                                   └──> default: log session.broker_return WARN
+Asíncronamente en el reader thread, si el broker no pudo rutear:
+   broker ──basic.return──> Exchange#on_return ──> Session#handle_broker_return
+                                                       │
+                                                       ├─ signal_return_listener   (busca cid en @pending_returns,
+                                                       │                            setea slot.info + slot.event)
+                                                       │
+                                                       └─ dispatch_return_callback (invoca Configuration#on_return
+                                                                                    o logea session.broker_return)
 ```
 
 ### `Configuration#on_return`
@@ -229,14 +246,43 @@ Excepciones del callback se capturan y se logean como `session.on_return_failed`
 | Auditoría, billing, eventos críticos | `:confirmed` (con `mandatory: true` si es ruteable) |
 | Request-response síncrono | `:rpc` |
 
-`:confirmed` cuesta un round-trip al broker pero **no** al consumer remoto — más rápido que RPC, con garantía de entrega al broker. NACK del broker es raro (típicamente por confirm policies internas, disk full, replicación insuficiente) pero **sí** implica que el mensaje no fue aceptado. Por default BugBunny levanta `BugBunny::PublishNacked` para que el caller pueda escalar (ej: convertir a HTTP 503 y dejar que el sistema upstream reintente). Opt-out con `config.nack_raise = false` o `nack_raise: false` per request.
+`:confirmed` cuesta un round-trip al broker pero **no** al consumer remoto — más rápido que RPC, con garantía de entrega al broker. Dos modos de falla broker-side, ambos raise-eables por default:
+
+- **NACK** (raro: confirm policies internas, disk full, replicación insuficiente) → `BugBunny::PublishNacked` (`path`, `nacked_count`). Opt-out: `config.nack_raise = false`.
+- **basic.return + mandatory** (queue inexistente, sin bindings, routing key sin match) → `BugBunny::PublishUnroutable` (`path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id`). Opt-out: `config.return_raise = false`.
+
+El `on_return` user callback se invoca igual antes del raise (orden: signal interno → user_cb → raise en caller), así que alerting/metrics siguen funcionando.
+
+### Bridge cross-thread (`basic.return` → publish thread)
+
+`basic.return` llega en el reader thread de Bunny mientras el publish thread está dentro de `wait_for_confirms`. Para que `PublishUnroutable` sea raise-eable sincrónicamente desde la perspectiva del caller, `Session` mantiene un registry indexado por `correlation_id`:
+
+```ruby
+# Session (api privada)
+@pending_returns = Concurrent::Map.new
+# slot = { event: Concurrent::Event.new, info: nil }
+```
+
+`Producer#confirmed`:
+1. Si `return_raise?` resuelto es true, auto-asigna `request.correlation_id` si falta (UUID v4 vía `SecureRandom`).
+2. Registra slot vía `Session#register_return_listener(cid)`.
+3. Publica con `correlation_id` propagado a las message properties (el broker lo echo back en `basic.return.properties`).
+4. Tras `wait_for_confirms` true, `event.wait(RETURN_RACE_WINDOW_S = 0.05)` para tolerar GVL scheduling. AMQP wire garantiza `return → ack`, así que normalmente el event ya está seteado.
+5. Si `slot[:info]` no es nil, logea `producer.publish_unroutable` y raise.
+6. `ensure` block siempre llama `Session#unregister_return_listener(cid)` para cleanup.
+
+`Session#handle_broker_return` (reader thread):
+1. `signal_return_listener` busca cid por `properties.correlation_id`, setea `slot[:info]` y `slot[:event]`. **Esto corre ANTES del user_cb** — una excepción en el callback no impide el raise.
+2. `dispatch_return_callback` invoca `Configuration#on_return` o logea `session.broker_return`.
+
+Si `return_raise: true` se pasa sin `confirmed: true` o sin `mandatory: true`, el flag es inerte y se emite `client.return_raise_ignored` WARN. El bridge no aplica en `:publish` puro porque no hay synchronization point (`wait_for_confirms`) sobre el cual raise-ear en el caller.
 
 ## Cascada de Configuración (3 niveles)
 
 ```ruby
-# Level 1: Gem defaults
-{ durable: false, auto_delete: false }   # exchanges
-{ exclusive: false, durable: false, auto_delete: true }  # queues
+# Level 1: Gem defaults (BugBunny::Session)
+{ durable: false, auto_delete: false }                       # DEFAULT_EXCHANGE_OPTIONS
+{ exclusive: false, durable: true, auto_delete: false }      # DEFAULT_QUEUE_OPTIONS (cambio en 4.16)
 
 # Level 2: Global config
 BugBunny.configure { |c| c.exchange_options = { durable: true } }
@@ -246,3 +292,5 @@ client.request('users', exchange_options: { durable: true })
 
 # Merge final: Level1.merge(Level2).merge(Level3)
 ```
+
+**Nota 4.16+:** `DEFAULT_QUEUE_OPTIONS` previamente era `{ exclusive: false, durable: false, auto_delete: true }` (combo `transient_nonexcl_queues` deprecada en RabbitMQ 4.x). El nuevo default es queue compartida duradera. Para restaurar el comportamiento previo: `c.queue_options = { exclusive: false, durable: false, auto_delete: true }`.

--- a/skill/references/errores.md
+++ b/skill/references/errores.md
@@ -9,6 +9,7 @@ StandardError
     ├── BugBunny::ConfigurationError
     ├── BugBunny::SecurityError
     ├── BugBunny::PublishNacked
+    ├── BugBunny::PublishUnroutable
     ├── BugBunny::ClientError (4xx)
     │   ├── BugBunny::BadRequest (400)
     │   ├── BugBunny::NotFound (404)
@@ -43,6 +44,12 @@ StandardError
 **Cuándo:** `Producer#confirmed` detecta `wait_for_confirms == false`. Se levanta por default (`config.nack_raise = true`).
 **Atributos:** `path` (ruta del request) y `nacked_count` (cantidad de delivery tags NACKeados).
 **Resolución:** Para casos críticos (auditoría, billing, RADIUS accounting), dejar que la excepción bubble para que el caller upstream reintente (ej: HTTP 503 → retry). Para tolerar NACKs (eventos best-effort), `BugBunny.configuration.nack_raise = false` global o `nack_raise: false` per request — en ese caso solo se logea `producer.confirms_nacked`.
+
+### BugBunny::PublishUnroutable
+**Causa:** El broker retornó un mensaje publicado con `mandatory: true` que no pudo rutearse a ninguna cola en modo `:confirmed` (queue inexistente, sin bindings que matcheen la routing key, etc.). Espejo simétrico de `PublishNacked` pero para la señal `basic.return` en lugar de `basic.nack`.
+**Cuándo:** `Producer#confirmed` con `mandatory: true` detecta un `basic.return` correlacionado por `correlation_id` antes/durante el ACK. Se levanta por default (`config.return_raise = true`, introducido en 4.15).
+**Atributos:** `path`, `exchange`, `routing_key`, `reply_code` (típicamente 312 = NO_ROUTE), `reply_text` y `correlation_id`.
+**Resolución:** Mismo patrón que `PublishNacked` — bubble en publishers críticos para traducir a HTTP 5xx + retry upstream. El `config.on_return` callback se sigue invocando antes del raise (alerting/metrics intactos). Para opt-out: `config.return_raise = false` global o `return_raise: false` per request. Inert cuando `mandatory: false` (sin mandatory el broker nunca emite `basic.return`).
 
 ## Errores de Cliente (4xx)
 


### PR DESCRIPTION
Refs #39, #42, #43.

## Summary

PR #39 (return_raise) y PR #43 (DEFAULT_QUEUE_OPTIONS durable) entregaron las features pero **no actualizaron las docs**. Este PR cubre ambas audiencias (humana + agente) antes de soltar v4.16.0.

## Audiencias

| Doc | Audiencia | Cobertura |
|---|---|---|
| `README.md` | Humanos | Publisher Confirms options, exception hierarchy, BugBunny.configure example |
| `skill/SKILL.md` | Agentes AI | Glosario, catálogo de logs, configuración global, delivery modes, bridge cross-thread |
| `skill/references/client-middleware.md` | Agentes (deep dive) | Diagrama Producer#confirmed ampliado, nueva sección "Bridge cross-thread", cascade actualizada |
| `skill/references/errores.md` | Agentes | `PublishUnroutable` entry detallada + jerarquía actualizada |

## Highlights

### README (humans)
- Tabla "Two broker signals, two exceptions" alinea NACK / basic.return.
- Bloque `BugBunny.configure` ahora muestra `nack_raise` + `return_raise` ambos explícitos con orden documentado (`on_return` callback corre ANTES del raise).
- Exception hierarchy completa (agregadas `PublishNacked`, `PublishUnroutable`, `CommunicationError`, `ConfigurationError`, `SecurityError`, `RoutingError`).

### SKILL.md (agent)
- Glosario "Publisher Confirms" describe las dos señales (NACK + basic.return) con sus excepciones simétricas.
- Catálogo de eventos incluye `producer.publish_unroutable` y `client.return_raise_ignored`.
- Sección de delivery modes reescrita con tabla simétrica + ejemplo opt-out + descripción del bridge cross-thread con `RETURN_RACE_WINDOW_S = 0.05`.

### client-middleware.md (deep dive)
- Diagrama Producer#confirmed ampliado: setup_return_listener → publish → wait_for_confirms → handle_return_result → ensure teardown. Reader-thread split signal_return_listener / dispatch_return_callback documentado.
- Nueva sección "Bridge cross-thread" explica el registry `@pending_returns`, auto-asignación de `correlation_id`, orden signal-event-before-user-cb, race window AMQP wire vs GVL.
- Cascada de configuración actualizada con `DEFAULT_QUEUE_OPTIONS = { durable: true, ... }` y migration note 4.16+.

### errores.md
- `PublishUnroutable` como hermano de `PublishNacked` en la jerarquía.
- Entry completa: causa, cuándo, atributos (path, exchange, routing_key, reply_code, reply_text, correlation_id), resolución, opt-out, inert cases (`mandatory: false`).

## Test plan

- [x] `bundle exec rspec spec/unit/` → 206 examples, 0 failures (no toca código).
- [x] grep verificó que todas las referencias a la combo legacy `transient_nonexcl_queues` están actualizadas o documentadas como histórico.
- [x] Sin headings duplicados, sin links rotos.

## Métricas

- 4 archivos tocados, +138 / -25 LOC, 100% docs (cero código).

🤖 Generated with [Claude Code](https://claude.com/claude-code)