### PR TITLE
fix(client): wrap Bunny::Exception as CommunicationError (#49)

### DIFF
--- a/lib/bug_bunny.rb
+++ b/lib/bug_bunny.rb
@@ -80,7 +80,10 @@ module BugBunny
   # @option options [Integer] :continuation_timeout (15000) Timeout para operaciones RPC internas.
   #
   # @return [Bunny::Session] Una sesión de Bunny ya iniciada (`start` ya invocado).
-  # @raise [Bunny::TCPConnectionFailed] Si no se puede conectar al servidor.
+  # @raise [BugBunny::CommunicationError] Si no se puede establecer la conexión
+  #   (TCP fail, auth fail, vhost inválido, etc.). Envuelve cualquier
+  #   `Bunny::Exception` para preservar la frontera de abstracción del gem.
+  #   La excepción original queda en `.cause`.
   def self.create_connection(**options)
     conn_options = merge_connection_options(options)
     Bunny.new(conn_options).tap do |conn|
@@ -89,6 +92,10 @@ module BugBunny
       end
       conn.start
     end
+  rescue Bunny::Exception => e
+    raise BugBunny::CommunicationError,
+          "Failed to establish AMQP connection to #{conn_options[:host]}:#{conn_options[:port]}: " \
+          "#{e.class}: #{e.message}"
   end
 
   # Cierra la conexión global si existe.

--- a/lib/bug_bunny/client.rb
+++ b/lib/bug_bunny/client.rb
@@ -138,9 +138,19 @@ module BugBunny
     # Ejecuta la lógica de envío dentro del contexto del Pool.
     # Mapea los argumentos al objeto Request y ejecuta la cadena de middlewares.
     #
+    # Cualquier `Bunny::Exception` que nazca durante la adquisición de la conexión
+    # (`@pool.with` → `try_create`) o durante operaciones sobre una conexión rota
+    # in-flight (canal cerrado, conn perdida) se envuelve en
+    # {BugBunny::CommunicationError}. Esto preserva el contrato de abstracción del
+    # gem: los callers del `Client` no deberían tener que rescatar tipos de
+    # `Bunny::*`. La excepción original queda accesible vía `.cause` (Ruby la
+    # preserva automáticamente al re-raisear dentro del `rescue`).
+    #
     # @param url [String] La ruta destino.
     # @param args [Hash] Argumentos pasados a los métodos públicos.
     # @yield [req] Bloque para configuración adicional del Request.
+    # @raise [BugBunny::CommunicationError] Si la conexión TCP/AMQP falla durante
+    #   la adquisición del slot del pool o durante la operación.
     def run_in_pool(url, args)
       req = build_request(url, args)
 
@@ -151,8 +161,19 @@ module BugBunny
       # de los keyword args. Evaluamos el warning sobre el estado final del Request.
       warn_return_raise_misuse(req)
 
-      # Ejecución dentro del Pool.
-      # Session y Producer se reutilizan por slot de conexión (ver #session_for / #producer_for).
+      execute_in_pool(req)
+    rescue BugBunny::Error
+      raise
+    rescue Bunny::Exception => e
+      raise BugBunny::CommunicationError, "AMQP failure on path=#{req&.path}: #{e.class}: #{e.message}"
+    end
+
+    # Ejecuta el Request dentro del Pool. Session y Producer se reutilizan por
+    # slot de conexión (ver #session_for / #producer_for).
+    #
+    # @param req [BugBunny::Request]
+    # @return [Hash] Respuesta del producer.
+    def execute_in_pool(req)
       @pool.with do |conn|
         session  = session_for(conn)
         producer = producer_for(conn, session)

--- a/lib/bug_bunny/exception.rb
+++ b/lib/bug_bunny/exception.rb
@@ -7,8 +7,24 @@ module BugBunny
   # Permite capturar cualquier error de la librería con un `rescue BugBunny::Error`.
   class Error < ::StandardError; end
 
-  # Error lanzado cuando ocurren problemas de red o conexión con RabbitMQ.
-  # Suele envolver excepciones nativas de la gema `bunny` (ej: TCP connection failure).
+  # Error lanzado cuando ocurren problemas de red, conexión o protocolo AMQP con RabbitMQ.
+  #
+  # Envuelve cualquier `Bunny::Exception` (TCP fail, auth fail, canal cerrado,
+  # `PreconditionFailed`, `ConnectionClosedError`, etc.) en las fronteras de
+  # abstracción del gem — `BugBunny.create_connection`, `BugBunny::Client#publish` /
+  # `#request` / `#send`, y `BugBunny::Producer#confirmed`. Los callers no deberían
+  # rescatar tipos de `Bunny::*` directamente: con `rescue BugBunny::CommunicationError`
+  # alcanza para cubrir cualquier fallo de transporte/broker.
+  #
+  # La excepción original queda accesible vía `.cause` (Ruby la preserva
+  # automáticamente al re-raisear dentro del `rescue`).
+  #
+  # @example
+  #   begin
+  #     client.publish('evt', exchange: 'x', body: payload)
+  #   rescue BugBunny::CommunicationError => e
+  #     logger.error("publish failed: #{e.message} cause=#{e.cause&.class}")
+  #   end
   class CommunicationError < Error; end
 
   # Error lanzado cuando la configuración de la gema es inválida.

--- a/lib/bug_bunny/producer.rb
+++ b/lib/bug_bunny/producer.rb
@@ -86,8 +86,8 @@ module BugBunny
       { 'status' => 202, 'body' => nil }
     rescue BugBunny::Error
       raise
-    rescue StandardError => e
-      raise BugBunny::CommunicationError, "Publisher confirms failed: #{e.message}"
+    rescue Bunny::Exception => e
+      raise BugBunny::CommunicationError, "Publisher confirms failed: #{e.class}: #{e.message}"
     ensure
       teardown_return_listener(request, return_listener)
     end

--- a/spec/unit/communication_error_wrapping_spec.rb
+++ b/spec/unit/communication_error_wrapping_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/bunny_mocks'
+
+# Specs para el contrato de envoltura definido en issue #49:
+# cualquier `Bunny::Exception` que escape de las fronteras de abstracción del
+# gem (`BugBunny.create_connection`, `BugBunny::Client#publish`/`#request`/`#send`,
+# `BugBunny::Producer#confirmed`) debe re-raisearse como
+# `BugBunny::CommunicationError`, preservando la excepción original en `.cause`.
+RSpec.describe 'Bunny::Exception → BugBunny::CommunicationError wrapping' do
+  include BunnyMocks
+
+  describe 'BugBunny.create_connection' do
+    before { BugBunny.configuration ||= BugBunny::Configuration.new }
+
+    it 'envuelve Bunny::TCPConnectionFailedForAllHosts en CommunicationError' do
+      fake_session = instance_double(Bunny::Session)
+      allow(fake_session).to receive(:after_recovery_completed)
+      allow(fake_session).to receive(:start).and_raise(Bunny::TCPConnectionFailedForAllHosts)
+      allow(Bunny).to receive(:new).and_return(fake_session)
+
+      err = capture_error { BugBunny.create_connection(host: 'broker.invalid', port: 5672) }
+      expect(err).to be_a(BugBunny::CommunicationError)
+      expect(err.message).to match(/broker.invalid:5672/)
+      expect(err.cause).to be_a(Bunny::TCPConnectionFailed)
+    end
+
+    it 'envuelve cualquier Bunny::Exception, no solo TCP' do
+      fake_session = instance_double(Bunny::Session)
+      allow(fake_session).to receive(:after_recovery_completed)
+      allow(fake_session).to receive(:start).and_raise(Bunny::AuthenticationFailureError.new('guest', '/', 0))
+      allow(Bunny).to receive(:new).and_return(fake_session)
+
+      err = capture_error { BugBunny.create_connection }
+      expect(err).to be_a(BugBunny::CommunicationError)
+      expect(err.cause).to be_a(Bunny::AuthenticationFailureError)
+    end
+  end
+
+  describe 'Client#publish — TCP fail en try_create (issue #49 caso original)' do
+    it 'envuelve Bunny::TCPConnectionFailedForAllHosts levantado dentro de @pool.with' do
+      # Pool falso que levanta la excepción raw de bunny al adquirir slot —
+      # simula exactamente lo observado en producción en el stack trace del issue.
+      raising_pool = Object.new
+      raising_pool.define_singleton_method(:with) { |&_block| raise Bunny::TCPConnectionFailedForAllHosts }
+
+      client = BugBunny::Client.new(pool: raising_pool)
+
+      err = capture_error { client.publish('evt', exchange: 'x', exchange_type: 'direct', body: { a: 1 }) }
+      expect(err).to be_a(BugBunny::CommunicationError)
+      expect(err.message).to match(/AMQP failure on path=evt/)
+      expect(err.cause).to be_a(Bunny::TCPConnectionFailed)
+    end
+  end
+
+  describe 'Client — in-flight ConnectionClosedError' do
+    it 'envuelve Bunny::ConnectionClosedError levantado por el Producer' do
+      conn    = BunnyMocks::FakeConnection.new(true, BunnyMocks::FakeChannel.new(true))
+      pool    = Object.new.tap { |p| p.define_singleton_method(:with) { |&blk| blk.call(conn) } }
+      client  = BugBunny::Client.new(pool: pool)
+
+      allow_any_instance_of(BugBunny::Producer).to receive(:fire)
+        .and_raise(Bunny::ConnectionClosedError.new('connection lost'))
+
+      err = capture_error { client.publish('evt', exchange: 'x', exchange_type: 'direct', body: { a: 1 }) }
+      expect(err).to be_a(BugBunny::CommunicationError)
+      expect(err.message).to match(/AMQP failure/)
+      expect(err.cause).to be_a(Bunny::ConnectionClosedError)
+    end
+  end
+
+  describe 'Client — pass-through de BugBunny::Error' do
+    it 'no re-envuelve errores propios del gem (RequestTimeout, PublishNacked, etc.)' do
+      conn    = BunnyMocks::FakeConnection.new(true, BunnyMocks::FakeChannel.new(true))
+      pool    = Object.new.tap { |p| p.define_singleton_method(:with) { |&blk| blk.call(conn) } }
+      client  = BugBunny::Client.new(pool: pool)
+
+      allow_any_instance_of(BugBunny::Producer).to receive(:rpc)
+        .and_raise(BugBunny::RequestTimeout.new('timeout'))
+
+      expect { client.request('foo', method: :get, exchange: 'x', exchange_type: 'direct') }
+        .to raise_error(BugBunny::RequestTimeout)
+    end
+  end
+
+  describe 'Producer#confirmed — rescue limitado a Bunny::Exception' do
+    it 'no traga errores genéricos de Ruby (NoMethodError) como CommunicationError' do
+      producer = BugBunny::Producer.new(instance_double(BugBunny::Session))
+      allow(producer).to receive(:setup_return_listener).and_return(nil)
+      allow(producer).to receive(:teardown_return_listener)
+      allow(producer).to receive(:publish_message).and_raise(NoMethodError.new('bug interno'))
+
+      request = BugBunny::Request.new('evt').tap do |r|
+        r.exchange = 'x'
+        r.exchange_type = 'direct'
+        r.delivery_mode = :confirmed
+      end
+
+      expect { producer.confirmed(request) }.to raise_error(NoMethodError, 'bug interno')
+    end
+
+    it 'envuelve Bunny::Exception como CommunicationError' do
+      producer = BugBunny::Producer.new(instance_double(BugBunny::Session))
+      allow(producer).to receive(:setup_return_listener).and_return(nil)
+      allow(producer).to receive(:teardown_return_listener)
+      allow(producer).to receive(:publish_message)
+        .and_raise(Bunny::ChannelAlreadyClosed.new('closed', double(id: 1)))
+
+      request = BugBunny::Request.new('evt').tap do |r|
+        r.exchange = 'x'
+        r.exchange_type = 'direct'
+        r.delivery_mode = :confirmed
+      end
+
+      err = capture_error { producer.confirmed(request) }
+      expect(err).to be_a(BugBunny::CommunicationError)
+      expect(err.message).to match(/Publisher confirms failed/)
+      expect(err.cause).to be_a(Bunny::ChannelAlreadyClosed)
+    end
+  end
+
+  def capture_error
+    yield
+    nil
+  rescue StandardError => e
+    e
+  end
+end

--- a/spec/unit/producer_spec.rb
+++ b/spec/unit/producer_spec.rb
@@ -377,11 +377,19 @@ RSpec.describe BugBunny::Producer do
       expect { confirmed_producer.confirmed(req) }.to raise_error(BugBunny::RequestTimeout, /Timeout/)
     end
 
-    it 'envuelve errores del canal como BugBunny::CommunicationError' do
-      allow(mock_channel).to receive(:wait_for_confirms).and_raise(StandardError, 'boom')
+    it 'envuelve Bunny::Exception del canal como BugBunny::CommunicationError' do
+      allow(mock_channel).to receive(:wait_for_confirms)
+        .and_raise(Bunny::ChannelAlreadyClosed.new('boom', double(id: 1)))
 
       expect { confirmed_producer.confirmed(build_request) }
         .to raise_error(BugBunny::CommunicationError, /boom/)
+    end
+
+    it 'no traga errores genéricos de Ruby (rescue es Bunny::Exception, no StandardError)' do
+      allow(mock_channel).to receive(:wait_for_confirms).and_raise(NoMethodError, 'bug interno')
+
+      expect { confirmed_producer.confirmed(build_request) }
+        .to raise_error(NoMethodError, 'bug interno')
     end
 
     it 'propaga BugBunny::Error sin envolver' do


### PR DESCRIPTION
## Summary

Fix issue #49 — `Client#publish` dejaba escapar `Bunny::TCPConnectionFailedForAllHosts` raw cuando el broker estaba inalcanzable, rompiendo la frontera de abstracción documentada por `BugBunny::CommunicationError`. El TCP fail nace en `ConnectionPool::TimedStack#try_create` dentro del `@pool.with`, **antes** de entrar al `Producer#confirmed` que ya envolvía con `rescue StandardError`.

Closes #49.

### Cambios

- **`Client#run_in_pool`** envuelve `Bunny::Exception` → `BugBunny::CommunicationError`. Cubre los dos caminos:
  - Fallo en `try_create` (conn nueva, caso original del issue).
  - `Bunny::ConnectionClosedError` in-flight sobre una conn rota mid-publish.

  Extraje `execute_in_pool` privado para mantener `Metrics/AbcSize` sin disable.

- **`BugBunny.create_connection`** envuelve también (Railtie, tests, scripts que llaman directo). YARD `@raise` actualizado a `BugBunny::CommunicationError`.

- **`Producer#confirmed`**: rescue estrechado de `rescue StandardError` a `rescue Bunny::Exception`. Razón: no tragar bugs internos (`NoMethodError`, `KeyError`) bajo la etiqueta de fallo de transporte. Consistente con el rescue del Client.

- **`CommunicationError` docstring**: expandido. Ahora declara que envuelve cualquier `Bunny::Exception`, no solo TCP. La excepción original queda en `.cause` (Ruby la preserva automáticamente).

### Behavior change (menor)

Callers que hoy rescatan **`Bunny::TCPConnectionFailed` directo** deben migrar a `BugBunny::CommunicationError`. El `@raise` previo de `create_connection` era un leak documentado, no contrato fuerte. Recomendación: bump minor al hacer `/gem-release`.

Callers que ya rescatan `BugBunny::Error` o `BugBunny::CommunicationError`: **sin cambios**, todo sigue funcionando.

## Test plan

- [x] `spec/unit/communication_error_wrapping_spec.rb` (7 ejemplos nuevos):
  - `create_connection` envuelve `Bunny::TCPConnectionFailedForAllHosts` + preserva `.cause`.
  - `create_connection` envuelve `Bunny::AuthenticationFailureError`.
  - `Client#publish` envuelve TCP fail levantado dentro de `@pool.with` (reproduce stack del issue).
  - `Client#publish` envuelve `Bunny::ConnectionClosedError` in-flight desde el Producer.
  - `Client` pass-through de `BugBunny::Error` (no re-envuelve).
  - `Producer#confirmed` no traga `NoMethodError` como `CommunicationError`.
  - `Producer#confirmed` envuelve `Bunny::ChannelAlreadyClosed`.
- [x] Spec preexistente del producer adaptado al rescue más estrecho (`Bunny::ChannelAlreadyClosed` en vez de `StandardError`).
- [x] Suite unit completa: `bundle exec rspec spec/unit` → 221/221 verde.
- [x] Suite integration: `bundle exec rspec spec/integration` → 44/44 verde.
- [x] RuboCop limpio sobre archivos modificados (offenses restantes son preexistentes en `Producer#rpc` y `log_request`).
- [ ] Validación adicional sugerida: probar contra `box_radius_manager 0.7.0` con RabbitMQ caído — debería levantar `BugBunny::CommunicationError` en vez de `Bunny::TCPConnectionFailedForAllHosts`.

## Versionado / release

Sin bump en este PR — version + CHANGELOG los maneja `/gem-release` post-merge. Sugerido: **minor (4.18.0)** por el behavior change documentado arriba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)