### PR TITLE
docs(release): re-anclar release.md a RFC-014 accepted + v4.19.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,11 @@ BugBunny es una gema Ruby que implementa una capa de enrutamiento RESTful sobre 
 - **Estado actual:** `docs/data` = n/a (gema sin DB, declarado solo en índice);
   `docs/glossary` parcial (acreta por PR); `docs/behavior` completo (6 flujos,
   backfill on-demand); operaciones/interfaz/topología = dev-structure F2 no
-  implementado.
+  implementado; `docs/errors` (RFC-020) **pendiente** — la jerarquía de
+  excepciones públicas (`exception.rb`, `remote_error.rb`,
+  `middleware/raise_error.rb`) existe y #52 sumó `status`/`raw_response`; el
+  contrato de error vive hoy embebido en `docs/behavior/behavior.md` + composites
+  (interim RFC-008 §2). Generar la capa con `arch-structure` cuando se priorice.
 - **Para agentes AI**: `skill/SKILL.md` (empaquetada en el `.gem`) +
   `skill/references/`.
 - **Coexistencia transitoria con destino pendiente (RFC-008 §2 — interim de

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,10 @@ BugBunny es una gema Ruby que implementa una capa de enrutamiento RESTful sobre 
 - **Estado actual:** `docs/data` = n/a (gema sin DB, declarado solo en índice);
   `docs/glossary` parcial (acreta por PR); `docs/behavior` completo (6 flujos,
   backfill on-demand); operaciones/interfaz/topología = dev-structure F2 no
-  implementado; `docs/errors` (RFC-020) **pendiente** — la jerarquía de
-  excepciones públicas (`exception.rb`, `remote_error.rb`,
-  `middleware/raise_error.rb`) existe y #52 sumó `status`/`raw_response`; el
-  contrato de error vive hoy embebido en `docs/behavior/behavior.md` + composites
-  (interim RFC-008 §2). Generar la capa con `arch-structure` cuando se priorice.
+  implementado; `docs/errors` (RFC-020) **estructura completa** (§a inventario de
+  excepciones + §b status→excepción + §d shape de payload; jerarquía bajo
+  `BugBunny::Error`, #52 sumó `status`/`raw_response`), §c política sembrada `—`
+  (pendiente de `arch-enrich`).
 - **Para agentes AI**: `skill/SKILL.md` (empaquetada en el `.gem`) +
   `skill/references/`.
 - **Coexistencia transitoria con destino pendiente (RFC-008 §2 — interim de

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -1,0 +1,168 @@
+# Errores — bug_bunny
+
+> meta: artefacto errores · RFC-020 (parte estructural) · generado `arch-structure`
+> · anclado a `5d7851a`, `lib/bug_bunny/exception.rb`, `remote_error.rb`,
+> `middleware/raise_error.rb`, `controller.rb`, `consumer.rb` · fecha 2026-06-30
+> · cobertura: §a/§b/§d completas (régimen estructura); §c sembrado `—`
+> (política → `arch-enrich`).
+
+## 1. Resumen
+
+Catálogo del unhappy path que la gema **emite** a sus consumidores: jerarquía de
+excepciones bajo `BugBunny::Error`, el mapeo `status RPC → excepción` que aplica
+`Middleware::RaiseError` en el lado cliente, y el shape del envelope de error que
+emite el lado worker (`Controller`). La gema es **agnóstica al payload**: expone
+la materia prima (`status` + `raw_response`) y no interpreta la estructura de
+dominio del cuerpo (#52).
+
+## 2. Cuerpo
+
+### a. Inventario de excepciones públicas
+
+Jerarquía (todas bajo `BugBunny::Error < ::StandardError`):
+
+```
+::StandardError
+└── BugBunny::Error                      base · attr_accessor :status, :raw_response (#52)
+    ├── CommunicationError               fallo de red/conexión/protocolo AMQP
+    ├── ConfigurationError               configuración inválida de la gema
+    ├── SecurityError                    acceso no permitido a controladores (anti-RCE)
+    ├── PublishNacked                    broker NACK en publish :confirmed
+    ├── PublishUnroutable                broker return (mandatory) sin binding
+    ├── ClientError                      base 4xx
+    │   ├── BadRequest                   400
+    │   ├── NotFound                     404
+    │   │   └── RoutingError             404 · ruta RPC inexistente en el remoto
+    │   ├── NotAcceptable                406
+    │   ├── RequestTimeout               408 · y timeout local de RPC
+    │   ├── Conflict                     409
+    │   └── UnprocessableEntity          422 · parsea body, expone error_messages
+    └── ServerError                      base 5xx
+        ├── InternalServerError          500 genérico
+        └── RemoteError                  500 · propaga excepción serializada del worker
+```
+
+| excepción | jerarquía base | qué la levanta (ancla) |
+|---|---|---|
+| `Error` | `::StandardError` | base — no se levanta directa salvo `resource.rb:122` (pool ausente) |
+| `CommunicationError` | `Error` | `bug_bunny.rb:96`, `session.rb:177,285`, `producer.rb:90`, `client.rb:168` — envuelve cualquier `Bunny::Exception` en la frontera del gem; original en `.cause` |
+| `ConfigurationError` | `Error` | `configuration.rb:262,269,277` — validación al final de `BugBunny.configure` |
+| `SecurityError` | `Error` | definida; sin raise-site localizado en `lib/` (ver §3) |
+| `PublishNacked` | `Error` | `producer.rb:235` — NACK del broker en modo `:confirmed`. Attrs: `path`, `nacked_count`. Opt-out `nack_raise: false` |
+| `PublishUnroutable` | `Error` | `producer.rb:325` — `basic.return` con `mandatory: true`. Attrs: `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id`. Opt-out `return_raise: false` |
+| `ClientError` | `Error` | `raise_error.rb:170` — 4xx no mapeado explícito |
+| `BadRequest` | `ClientError` | `raise_error.rb:38` — status 400 |
+| `NotFound` | `ClientError` | `raise_error.rb:155` — status 404 genérico |
+| `RoutingError` | `NotFound` | `raise_error.rb:152` — status 404 con `body['error_type'] == 'routing_error'` |
+| `NotAcceptable` | `ClientError` | `raise_error.rb:40` — status 406 |
+| `RequestTimeout` | `ClientError` | `raise_error.rb:41` (status 408) · `producer.rb:124,214` (timeout local de RPC) |
+| `Conflict` | `ClientError` | `raise_error.rb:42` — status 409 |
+| `UnprocessableEntity` | `ClientError` | `raise_error.rb:44` — status 422. Parsea body, expone `error_messages` (busca clave `errors`); setea `raw_response` en el ctor |
+| `ServerError` | `Error` | `raise_error.rb:168` — 5xx no mapeado explícito |
+| `InternalServerError` | `ServerError` | `raise_error.rb:67`, `producer.rb:396` (JSON inválido) — status 500 genérico |
+| `RemoteError` | `ServerError` | `raise_error.rb:63` — status 5xx con `body['bug_bunny_exception']`. Attrs: `original_class`, `original_message`, `original_backtrace` |
+
+> `ArgumentError`/`NameError` que levantan `client.rb:51`, `controller.rb:101,171`,
+> `routing/*` son de la API de configuración/programación (uso incorrecto del
+> dev), no del contrato runtime RPC — no se listan como contrato de error público.
+
+### b. Códigos de estado por superficie
+
+Mapeo `status → excepción` que aplica `Middleware::RaiseError#on_complete`
+(`raise_error.rb:32-48`) en el **lado cliente** del RPC. Referencia las
+operaciones de RFC-003 (`docs/api/`, hoy pendiente — ver §4), no las redefine.
+
+| superficie | status | excepción levantada | cuándo |
+|---|---|---|---|
+| Cliente RPC (`RaiseError`) | 200..299 | — (none) | éxito, flujo normal |
+| Cliente RPC | 400 | `BadRequest` | bad request |
+| Cliente RPC | 404 | `NotFound` / `RoutingError` | recurso / ruta RPC inexistente (`error_type: routing_error`) |
+| Cliente RPC | 406 | `NotAcceptable` | content negotiation |
+| Cliente RPC | 408 | `RequestTimeout` | timeout reportado por el remoto |
+| Cliente RPC | 409 | `Conflict` | conflicto de estado/negocio |
+| Cliente RPC | 422 | `UnprocessableEntity` | validación semántica del modelo remoto |
+| Cliente RPC | 500..599 | `RemoteError` / `InternalServerError` | error del worker (RemoteError si trae `bug_bunny_exception`) |
+| Cliente RPC | otro ≥500 | `ServerError` | 5xx no mapeado |
+| Cliente RPC | otro ≥400 | `ClientError` | 4xx no mapeado |
+| Productor (publish `:confirmed`) | n/a (AMQP) | `PublishNacked` / `PublishUnroutable` | NACK / return del broker — no es status HTTP |
+| Transporte (frontera gem) | n/a (AMQP) | `CommunicationError` | fallo de red/broker, envuelve `Bunny::Exception` |
+
+### c. Política por error
+
+`—` (sembrado · retriable/backoff/idempotencia/acción → `arch-enrich`, RFC-020 §c).
+
+### d. Shape del payload de error
+
+**Lado worker → wire (lo que emite `Controller#handle_exception`, `controller.rb:224-233`)**
+ante una excepción no mapeada por `rescue_from`:
+
+```json
+{
+  "status": 500,
+  "headers": { },
+  "body": {
+    "error": "Internal Server Error",
+    "detail": "<exception.message>",
+    "type": "<exception.class.name>",
+    "bug_bunny_exception": {
+      "class": "<clase original>",
+      "message": "<mensaje original>",
+      "backtrace": ["<hasta 25 líneas>"]
+    }
+  }
+}
+```
+
+- El envelope `bug_bunny_exception` lo arma `RemoteError.serialize` (`remote_error.rb:29`);
+  también lo agrega `Consumer` cuando `status == 500 && exception` (`consumer.rb:325`).
+  Es lo que el cliente reconstruye como `RemoteError` (`raise_error.rb:61-64`).
+- `render status:, json:` (`controller.rb:242`) deja el shape del body de error de
+  dominio a criterio del worker — la gema no lo impone.
+
+**Lado cliente — materia prima expuesta (#52).** Toda excepción derivada de una
+respuesta RPC trae, vía `RaiseError#raise_typed` (`raise_error.rb:82-86`):
+
+- `e.status` → `Integer` (el código de la respuesta).
+- `e.raw_response` → `Hash | String | nil` (el cuerpo crudo, **sin interpretar**).
+  `nil` para errores no-RPC (`CommunicationError`, `ConfigurationError`).
+
+**Shapes que `format_error_message` reconoce para el `.message` humano**
+(`raise_error.rb:110-141`, best-effort, **NO contrato**):
+
+1. Envelope anidado: `{ "error": { "message": "..." } }` → extrae `error.message`.
+2. Shape plano histórico: `{ "error": "texto", "detail": "..." }` → `"texto - detail"`.
+3. Fallback: `body.to_json` (nunca `Hash#inspect`).
+
+`UnprocessableEntity` además expone `error_messages` (`exception.rb:219-263`):
+parsea el body, devuelve `parsed['errors']` por convención o el cuerpo completo.
+
+> **Seguridad (cruza RFC-017):** `raw_response` puede contener datos sensibles en
+> `details`. La gema lo entrega crudo a propósito; **sanitizar antes de cualquier
+> sink** (Sentry/logs) filtrando `password|pass|passwd|secret|token|api_key|auth`
+> → `[FILTERED]` es responsabilidad del consumidor (`exception.rb:25-30`).
+
+## 3. Inferencias
+
+- **`SecurityError`** (`exception.rb:65`) está definida con docstring (anti-RCE,
+  valida herencia de clases enrutadas) pero **no se localizó su raise-site** en
+  `lib/` al commit `5d7851a`. `confidence: low` — puede levantarse en una capa de
+  routing no cubierta por el grep, ser aspiracional, o levantarse por el host. A
+  verificar con el dueño del código.
+- **§b superficies AMQP** (`PublishNacked`/`PublishUnroutable`/`CommunicationError`)
+  no tienen status HTTP: son señales del protocolo AMQP, no del envelope RPC. Se
+  listan como `n/a (AMQP)` para no forzar un código HTTP inventado.
+
+## 4. Cobertura y fronteras
+
+- **§a/§b/§d completas** al commit ancla; **§c sembrado `—`** (política →
+  `arch-enrich`).
+- **RFC-003 (`docs/api/`) pendiente:** §b referencia "superficie" de operaciones
+  pero la capa operaciones no está generada (dev-structure F2, ver `CLAUDE.md`).
+  Cuando se genere, §b debe cruzar las operaciones reales.
+- **Frontera con `consumed` (RFC-018):** este artefacto = errores que la gema
+  **emite**. Los errores de `Bunny::*` que la gema **consume** y envuelve en
+  `CommunicationError` son su mapeo error-proveedor→excepción; viven del lado
+  consumed (capa no generada — la gema consume `bunny`/`connection_pool`).
+- **Errores internos no-públicos** (rescatados adentro, no cruzan la frontera) y
+  los `ArgumentError`/`NameError` de mal-uso de la API de config quedan fuera:
+  no son contrato runtime.

--- a/docs/release/release.md
+++ b/docs/release/release.md
@@ -1,9 +1,9 @@
 # Release — bug_bunny
 
-> meta: artefacto release · RFC-014 (shape v2.0, `proposed`) · generado
-> manualmente (**piloto RFC-014** — suplemento gema, valida patrón 1 +
-> per-repo-visible) · anclado a `.github/workflows/release.yml`, `*.gemspec`,
-> `lib/bug_bunny/version.rb`, `CHANGELOG.md`, git · fecha 2026-06-01 · cobertura:
+> meta: artefacto release · RFC-014 (`accepted`) · generado por `arch-structure`
+> + `arch-enrich` (híbrido RFC-014 §2; nació como piloto manual #51, re-anclado
+> a la RFC vigente) · anclado a `.github/workflows/release.yml`, `*.gemspec`,
+> `lib/bug_bunny/version.rb`, `CHANGELOG.md`, git · fecha 2026-06-30 · cobertura:
 > completa (régimen gema: build→publish, §e/f/g n/a).
 
 ## 1. Resumen
@@ -20,9 +20,9 @@ out-of-repo).
 
 ### a. Hecho verificable
 
-- **Convención de versión:** SemVer `vX.X.X`. Actual: **4.18.0**.
-- **Source of truth:** tag remoto (`v4.18.0`) + **triple mirror**
-  `lib/bug_bunny/version.rb` (`VERSION = '4.18.0'`) ← `bug_bunny.gemspec:7`
+- **Convención de versión:** SemVer `vX.X.X`. Actual: **4.19.0**.
+- **Source of truth:** tag remoto (`v4.19.0`) + **triple mirror**
+  `lib/bug_bunny/version.rb` (`VERSION = '4.19.0'`) ← `bug_bunny.gemspec:7`
   (`spec.version = BugBunny::VERSION`).
 - **Changelog canónico:** `CHANGELOG.md` único.
 - **Patrón de trigger:** `gema-tag` (patrón 1).
@@ -33,7 +33,7 @@ out-of-repo).
 
 - **Convención:** SemVer `vX.X.X` (**con `v`** — distinto al servicio).
 - **Source of truth:** tag remoto canónico (`git tag --sort=-v:refname` →
-  `v4.18.0`).
+  `v4.19.0`).
 - **Mirror:** `lib/bug_bunny/version.rb` (`VERSION`), leído por
   `bug_bunny.gemspec:7` (`spec.version = BugBunny::VERSION`).
   `required_ruby_version >= 2.6.0` (`bug_bunny.gemspec:17`).
@@ -58,7 +58,7 @@ out-of-repo).
   `on: push: tags: ['v*']` → `ruby/setup-ruby@v1` → `gem build *.gemspec` +
   `gem push *.gem` (auth `secrets.RUBYGEMS_API_KEY`). Auditable y versionado con
   el código; se ancla a `file:line`, no se referencia como caja negra.
-- **Consumo:** los servicios la pinnean por versión (`gem "bug_bunny", "~> 4.18.0"`)
+- **Consumo:** los servicios la pinnean por versión (`gem "bug_bunny", "~> 4.19.0"`)
   desde RubyGems — **no** git-source.
 
 ### e. Deploy / publish
@@ -80,7 +80,7 @@ procedimiento per-repo porque no vive acá. Una versión yankeada se anotaría e
 ### h. Dependencias de deploy inter-servicio
 
 - **Consumidores** (cruza RFC-018): servicios del fleet la pinnean
-  `~> 4.18.0` (semántica minor-compatible). Un cambio de contrato del gem
+  `~> 4.19.0` (semántica minor-compatible). Un cambio de contrato del gem
   (ej. el behavior-change de `4.18.0` — `Bunny::Exception` → `CommunicationError`)
   obliga a los consumidores a migrar; el `CHANGELOG.md` lo documenta como
   breaking note. **Orden de deploy:** los consumidores adoptan al hacer `bundle


### PR DESCRIPTION
## Contexto

`critias --full` sobre el repo + síntesis cross-verificador con **opencode** y **agy** (multi-vendor-feedback). Este PR aplica las correcciones.

## Cambios

### `docs/release/release.md` — META-002 (consenso 3/3)
La meta del artefacto estaba stale en dos ejes que arrastraban los releases 4.18→4.19 sin regenerar:
- `RFC-014 (shape v2.0, proposed)` → **`RFC-014 (accepted)`** (ratificada 2026-06-01, gate `sequre/projects#136`). La RFC siempre fue la correcta; el sufijo `proposed` era el drift.
- Versión `4.18.0` → **`4.19.0`** en §a/§b/§d/§h (tag, triple-mirror, pin de consumidores). El ejemplo histórico del behavior-change `4.18.0` (`CommunicationError`) se **conserva** (es real).
- Generador `generado manualmente` → **`arch-structure` + `arch-enrich`** (híbrido RFC-014 §2; nació como piloto manual #51).

> Nota de severidad (síntesis): opencode + agy coinciden con la auto-nota de critias en que META-002 es **state drift**, no RFC equivocada → clasificable como *warn*. La corrección de re-anclaje es la misma en cualquier caso.

### `docs/errors/errors.md` — STRUCT-001 (errors) — **NUEVA CAPA**
Generada con `arch-structure` (RFC-020 estructural), anclada a `5d7851a`:
- **§a** Inventario de excepciones públicas: jerarquía completa bajo `BugBunny::Error` con qué la levanta (`file:line`).
- **§b** Mapeo `status RPC → excepción` (`Middleware::RaiseError#on_complete`) + señales AMQP (NACK/return/transporte) marcadas `n/a` (no son status HTTP).
- **§d** Shape del payload de error (envelope `bug_bunny_exception` del worker + materia prima `status`/`raw_response` del #52 + shapes de `format_error_message`).
- **§c** política sembrada `—` (pendiente `arch-enrich`).

⚠️ **Verificación humana pendiente:** `SecurityError` está definida sin raise-site localizado en `lib/` (marcado `confidence:low` en §3).

### `CLAUDE.md` — índice de capas
`docs/errors` pasa de "no declarada" → "estructura completa, §c pendiente de enrich".

## Follow-ups (otro PR — requieren skill + verificación humana)
- [ ] `arch-enrich` sobre `docs/errors/` §c (política retriable/backoff/idempotencia/acción).
- [ ] Materializar el stanza "Mapa de conocimiento" en `AGENTS.md` con `arch-compose` (hoy la cobertura vive en `CLAUDE.md`).

## Verificación
- Docs-only; sin código Ruby tocado.
- `grep 4.18.0 docs/release/release.md` → solo el ejemplo histórico de §h.
- `docs/errors/errors.md` sin Mermaid (árbol en fenced block) → cero riesgo de render roto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)