### PR TITLE
docs: completar cobertura de capas (config/consumed/test + errors §c + AGENTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — bug_bunny
+
+Entrada de harness para agentes que trabajan en este repo. Para el contrato de
+proyecto y convenciones de equipo, ver `CLAUDE.md`. Para la entrada humana, ver
+`README.md`; para la entrada agente version-locked, `skill/SKILL.md`.
+
+## Mapa de conocimiento
+
+> Stanza RFC-008 r2 — **indexa, no duplica**. Cada fila apunta al artefacto de
+> detalle que es la fuente de verdad de esa capa. Leé el artefacto antes de
+> responder sobre su capa.
+
+| capa | artefacto | estado | qué responde |
+|---|---|---|---|
+| Comportamiento | `docs/behavior/behavior.md` | completo (6 flujos) | secuencias de publish/RPC/consume/confirms, contrato de error-wrapping |
+| Glosario | `docs/glossary/glossary.md` | parcial (acreta por PR) | término de negocio → binding físico en `lib/` |
+| Errores | `docs/errors/errors.md` | completo (§a/b/d estructura + §c política inferida) | jerarquía de excepciones públicas, mapeo `status→excepción`, shape del payload, política retry |
+| Configuración | `docs/config/configuracion.md` | inventario base completo | opciones de `Configuration`, defaults, inyecciones del `Railtie`, ENV sugeridas al consumidor |
+| Dependencias consumidas | `docs/consumed/rabbitmq.md` | §a/b/d completo | qué consume del broker RabbitMQ vía `bunny`, mapeo error-Bunny→excepción |
+| Test | `docs/test/test.md` | estructura completa | suites RSpec/Minitest, comandos, CI, fixtures |
+| Release | `docs/release/release.md` | completo | patrón gema-tag, versionado, publish a RubyGems |
+| Datos | — | n/a | gema sin DB |
+| Operaciones / Interfaz / Topología | — | dev-structure F2 no implementado | contrato embebido en `README.md`/`skill/SKILL.md` (interim RFC-008 §2) |
+
+## Enriquecimiento pendiente (`arch-enrich`)
+
+- `docs/errors/errors.md` §c — política inferida de HTTP/AMQP, falta confirmar con dueño.
+- `docs/config/configuracion.md` §f/§g/§h/§j — semántica/failure-mode/threading.
+- `docs/consumed/rabbitmq.md` §c/§e — retry/idempotencia + degradación si RabbitMQ cae.
+- `docs/test/test.md` §e-§h — gaps de cobertura, contract-assessment, link a incidente, PII.
+
+## Convenciones operativas
+
+- Ruby: `.ruby-version` · gemas: `Gemfile.lock` · manager: chruby + Bundler.
+- Antes de commitear: `bundle exec rubocop -a` (base `rubocop-rails-omakase`),
+  `bundle exec rspec`, YARD incremental (`bundle exec yard stats --list-undoc`).
+- Releases: `/gem-release` (el GitHub Action publica a RubyGems al pushear tag `v*`).
+- Doc por-PR: si tocás una capa, mové su artefacto en el mismo PR (régimen RFC-001).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ proyecto y convenciones de equipo, ver `CLAUDE.md`. Para la entrada humana, ver
 | Release | `docs/release/release.md` | completo | patrón gema-tag, versionado, publish a RubyGems |
 | Datos | — | n/a | gema sin DB |
 | Operaciones / Interfaz / Topología | — | dev-structure F2 no implementado | contrato embebido en `README.md`/`skill/SKILL.md` (interim RFC-008 §2) |
+| Eventos (RFC-005) | — | n/a | la gema es el transporte de eventos, no declara un catálogo de eventos de dominio propio |
+| Seguridad (RFC-017) | — | n/a | sin authn/authz propias; el único control es `SecurityError` (validación de herencia de controladores), cubierto en `docs/errors/` |
+| Multi-tenancy (RFC-023) | — | n/a | sin modelo de tenant propio; el aislamiento es por `vhost` de RabbitMQ (config) |
+| Data-lifecycle (RFC-026) | — | n/a | gema sin DB ni datos persistidos propios |
 
 ## Enriquecimiento pendiente (`arch-enrich`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,20 @@ BugBunny es una gema Ruby que implementa una capa de enrutamiento RESTful sobre 
   `skill/SKILL.md` agente version-locked) **indexan, no duplican**.
   Artefactos generados por `dev-structure` / `dev-enrich`; compuestos por
   `dev-compose`. Verificación humana antes de commitear.
-- **Estado actual:** `docs/data` = n/a (gema sin DB, declarado solo en índice);
-  `docs/glossary` parcial (acreta por PR); `docs/behavior` completo (6 flujos,
-  backfill on-demand); operaciones/interfaz/topología = dev-structure F2 no
-  implementado; `docs/errors` (RFC-020) **estructura completa** (§a inventario de
-  excepciones + §b status→excepción + §d shape de payload; jerarquía bajo
-  `BugBunny::Error`, #52 sumó `status`/`raw_response`), §c política sembrada `—`
-  (pendiente de `arch-enrich`).
+- **Estado actual:**
+  - `docs/data` = n/a (gema sin DB, declarado solo en índice).
+  - `docs/behavior` completo (6 flujos, backfill on-demand).
+  - `docs/glossary` parcial (acreta por PR).
+  - `docs/errors` (RFC-020) completo: §a/§b/§d (estructura) + §c política
+    (enrich, **inferida** de HTTP/AMQP, verificación humana pendiente).
+  - `docs/config` (RFC-012) inventario base completo (§a-§e/§i); enriquecimiento
+    semántico (§f/§g/§h/§j) pendiente de `arch-enrich`.
+  - `docs/consumed` (RFC-018) RabbitMQ-vía-`bunny`: §a/§b/§d completo; §c/§e
+    (retry/degradación) pendiente de `arch-enrich`.
+  - `docs/test` (RFC-013) estructura completa (§a-§d); §e-§h (gaps/contract/
+    incidente/PII) pendiente de `arch-enrich`.
+  - operaciones/interfaz/topología (RFC-003/004/006) = dev-structure F2 no
+    implementado (interim RFC-008 §2).
 - **Para agentes AI**: `skill/SKILL.md` (empaquetada en el `.gem`) +
   `skill/references/`.
 - **Coexistencia transitoria con destino pendiente (RFC-008 §2 — interim de

--- a/docs/config/configuracion.md
+++ b/docs/config/configuracion.md
@@ -1,0 +1,133 @@
+# Configuración — bug_bunny
+
+> meta: artefacto configuración · RFC-012 (inventario base shape v2.2) · generado
+> `arch-structure` · anclado a `5eea236`, `lib/bug_bunny/configuration.rb`,
+> `lib/bug_bunny.rb`, `lib/bug_bunny/railtie.rb`,
+> `lib/generators/bug_bunny/install/templates/initializer.rb` · fecha 2026-06-30
+> · cobertura: §a/§b/§c/§d/§e/§i completas; enriquecimiento (§f categoría/
+> failure-mode/side-effect, §g/§h/§j) sembrado `—` (→ `arch-enrich`).
+
+## 1. Resumen
+
+Gema configurable vía `BugBunny.configure { |c| ... }` (`bug_bunny.rb:59`) sobre
+la clase `Configuration` (`configuration.rb`): atributos con **code-defaults**
+seguros, validados por `validate!` al cierre del bloque. La gema **no lee `ENV[`
+en `lib/`**; el `ENV.fetch` vive en el **template** que sugiere al consumidor
+(`initializer.rb`). Inyecta al host vía `Railtie`.
+
+## 2. Cuerpo
+
+### a. Hecho verificable
+
+- **Total opciones (`Configuration`):** 29 (attr_accessor/reader).
+- **Validadas requeridas (`VALIDATIONS`, `configuration.rb:25-37`):** 5 (`host`,
+  `port`, `username`, `password`, `vhost` — `required: true`; igual tienen
+  default, `validate!` exige no-vacío).
+- **Con default:** 29 (todas; defaults en `initialize`/`init_callback_defaults`).
+- **Con rango validado:** 6 (`port`, `heartbeat`, `connection_timeout`,
+  `read_timeout`, `write_timeout`, `rpc_timeout`, `channel_prefetch`).
+- **Secretas (por nombre):** 1 (`password`).
+- **ENV leídas por la gema en `lib/`:** 0 (config 100% por code-default + bloque).
+
+### b. Inventario base
+
+Origen `code-default` salvo nota. Consumidor = `configuration.rb` (default en
+`initialize`) salvo indicado.
+
+| nombre | tipo | requerida | default | origen | consumidor | secret? |
+|---|---|---|---|---|---|---|
+| `host` | String | sí (validate!) | `'127.0.0.1'` | code-default | `configuration.rb:182` | no |
+| `port` | Integer | sí (validate!, 1..65535) | `5672` | code-default | `:183` | no |
+| `username` | String | sí (validate!) | `'guest'` | code-default | `:184` | no |
+| `password` | String | sí (validate!) | `'guest'` | code-default | `:185` | **sí** |
+| `vhost` | String | sí (validate!) | `'/'` | code-default | `:186` | no |
+| `logger` | Logger | no | `Logger.new($stdout)` INFO | code-default | `:188` | no |
+| `bunny_logger` | Logger | no | `Logger.new($stdout)` WARN | code-default | `:191` | no |
+| `automatically_recover` | Boolean | no | `true` | code-default | `:193` | no |
+| `network_recovery_interval` | Integer | no | `5` | code-default | `:194` | no |
+| `max_reconnect_attempts` | Integer/nil | no | `nil` (reintenta ∞) | code-default | `:195` | no |
+| `max_reconnect_interval` | Integer | no | `60` | code-default | `:196` | no |
+| `connection_timeout` | Integer | no (1..300) | `10` | code-default | `:197` | no |
+| `read_timeout` | Integer | no (1..300) | `30` | code-default | `:198` | no |
+| `write_timeout` | Integer | no (1..300) | `30` | code-default | `:199` | no |
+| `heartbeat` | Integer | no (0..3600) | `15` | code-default | `:200` | no |
+| `continuation_timeout` | Integer (ms) | no | `15000` | code-default | `:201` | no |
+| `channel_prefetch` | Integer | no (1..10000) | `1` | code-default | `:202` | no |
+| `rpc_timeout` | Integer | no (1..3600) | `10` | code-default | `:203` | no |
+| `health_check_interval` | Integer | no | `60` | code-default | `:204` | no |
+| `health_check_file` | String/nil | no | `nil` (desactivado) | code-default | `:207` | no |
+| `controller_namespace` | String | no | `'BugBunny::Controllers'` | code-default | `:210` | no |
+| `log_tags` | Array | no | `[:uuid]` | code-default | `:212` | no |
+| `exchange_options` | Hash | no | `{}` | code-default | `:215` | no |
+| `queue_options` | Hash | no | `{}` | code-default | `:216` | no |
+| `consumer_middlewares` | Stack (attr_reader) | no | `Stack.new` | code-default | `:218` | no |
+| `rpc_reply_headers` | Proc/nil | no | `nil` | code-default | `:251` | no |
+| `on_rpc_reply` | Proc/nil | no | `nil` | code-default | `:252` | no |
+| `on_return` | Proc/nil | no | `nil` | code-default | `:253` | no |
+| `nack_raise` | Boolean | no | `true` | code-default | `:254` | no |
+| `return_raise` | Boolean | no | `true` | code-default | `:255` | no |
+
+> **Override por request:** `nack_raise` y `return_raise` se sobreescriben por
+> llamada con `nack_raise:` / `return_raise:` en `Client#publish` (scope-override
+> → detalle a `arch-enrich`).
+
+### c. Meta-templates
+
+El install template (`initializer.rb`) **sugiere al consumidor** wirear 4 ENV
+(la gema no las lee — el consumidor las pasa al bloque `configure`):
+
+| plantilla | template | instancias |
+|---|---|---|
+| `RABBITMQ_{X}` → `config.{y}` | `ENV.fetch('RABBITMQ_{X}', '{default}')` | `RABBITMQ_HOST`→host (`'localhost'`), `RABBITMQ_USERNAME`→username (`'guest'`), `RABBITMQ_PASSWORD`→password (`'guest'`), `RABBITMQ_VHOST`→vhost (`'/'`) |
+
+> `spec/spec_helper.rb` usa `RABBITMQ_HOST` / `RABBITMQ_USER` / `RABBITMQ_PASS`
+> (nombres distintos al template) — convención de test, no contrato.
+
+### d. Derivaciones simples
+
+- `url` ← `"amqp://#{username}:#{password}@#{host}:#{port}/#{vhost}"`
+  (`configuration.rb:225`).
+- `create_connection(**options)` ← `merge_connection_options(options)` sobre la
+  config global; las options explícitas pisan los defaults (`bug_bunny.rb:88`).
+
+### e. Scheduling
+
+**n/a** — la gema no trae `sidekiq.yml`/`queue.yml`/`recurring.yml` ni cron.
+`health_check_interval` es polling interno de salud, no un scheduler.
+
+### i. Inyecciones al host (`Railtie`, `railtie.rb`)
+
+| inyección | qué hace | ancla |
+|---|---|---|
+| `initializer 'bug_bunny.add_autoload_paths'` | registra `app/rabbit` en el autoloader (Zeitwerk, `eager_load: true`) si existe | `:15-18` |
+| `config.after_initialize` → `ForkTracker.after_fork` | cierra la conexión heredada en cada fork (Rails 7.1+) | `:24-26` |
+| `config.after_initialize` → `Puma.events.on_worker_boot` | mismo cierre, hook legacy Puma <5 | `:30-34` |
+| `rake_tasks` | carga `tasks/bug_bunny.rake` (`bug_bunny:sync`) | `:38-40` |
+| `Spring.after_fork` | cierra conexión en preloader Spring | `:43-47` |
+
+### f/g/h/j. Enriquecimiento
+
+`—` (categoría · failure-mode · side-effect · scope-override · business-reason ·
+ramificadores intra-config · threading · mapeo de inyección a gemas →
+`arch-enrich`, RFC-012).
+
+## 3. Inferencias
+
+- **`requerida` de host/port/username/password/vhost:** `VALIDATIONS` las marca
+  `required: true`, pero `initialize` les da default → nunca son `nil` salvo que
+  el consumidor las setee a `''`/`nil`. Marcadas `sí (validate!)`: el contrato es
+  "no-vacías al cierre del bloque", no "sin default". `confidence: high`.
+- **`password` secret?=sí** por nombre (regla RFC-012). El default `'guest'` es
+  el usuario default de RabbitMQ (placeholder), **no** un secreto real → ver §4.
+
+## 4. Cobertura y fronteras
+
+- §a/§b/§c/§d/§e/§i **completas** al commit ancla; enriquecimiento sembrado `—`.
+- **Linter de secretos (advisory):** `password` default `'guest'` y el template
+  `RABBITMQ_PASSWORD` default `'guest'` matchean el patrón de secreto, pero el
+  valor es el placeholder default de RabbitMQ, **no** un secreto hardcodeado. El
+  consumidor debe inyectar la credencial real vía ENV en prod (lo dice el header
+  del template). No es hallazgo de fuga.
+- **Fuera de alcance:** la semántica de cada timeout/flag (qué falla si se
+  setea mal, side-effects de threading de los callbacks `on_return`/
+  `on_rpc_reply` que corren en el hilo del consumidor de Bunny) → `arch-enrich`.

--- a/docs/config/configuracion.md
+++ b/docs/config/configuracion.md
@@ -24,7 +24,7 @@ en `lib/`**; el `ENV.fetch` vive en el **template** que sugiere al consumidor
   `port`, `username`, `password`, `vhost` — `required: true`; igual tienen
   default, `validate!` exige no-vacío).
 - **Con default:** 29 (todas; defaults en `initialize`/`init_callback_defaults`).
-- **Con rango validado:** 6 (`port`, `heartbeat`, `connection_timeout`,
+- **Con rango validado:** 7 (`port`, `heartbeat`, `connection_timeout`,
   `read_timeout`, `write_timeout`, `rpc_timeout`, `channel_prefetch`).
 - **Secretas (por nombre):** 1 (`password`).
 - **ENV leídas por la gema en `lib/`:** 0 (config 100% por code-default + bloque).

--- a/docs/consumed/rabbitmq.md
+++ b/docs/consumed/rabbitmq.md
@@ -1,0 +1,90 @@
+# Dependencia consumida: RabbitMQ (vía `bunny`) — bug_bunny
+
+> meta: artefacto consumed · RFC-018 (estructural §a/§b/§d) · generado
+> `arch-structure` · anclado a `5eea236`, `bug_bunny.gemspec`,
+> `lib/bug_bunny.rb`, `lib/bug_bunny/session.rb`, `lib/bug_bunny/producer.rb`,
+> `lib/bug_bunny/middleware/raise_error.rb` · fecha 2026-06-30 · cobertura:
+> §a/§b/§d completas; §c (retry/idempotencia) y §e (degradación) sembrados `—`
+> (→ `arch-enrich`).
+
+## 1. Resumen
+
+La gema consume **un único sistema externo: el broker RabbitMQ**, vía el SDK
+`bunny ~> 2.24` (AMQP 0-9-1). Es el corazón del gem: toda publicación, consumo,
+RPC y declaración de infraestructura pasa por `Bunny`. El pooling de conexiones
+lo da `connection_pool` (infra, ver §4).
+
+## 2. Cuerpo
+
+### a. Identidad
+
+| campo | valor |
+|---|---|
+| proveedor / sistema | **RabbitMQ broker** |
+| sub-tipo | **externo** (sistema de mensajería, no un repo del fleet) |
+| transporte | AMQP 0-9-1 (TCP) |
+| cliente nuestro | gem `bunny ~> 2.24` (`bug_bunny.gemspec:36`), envuelto por `BugBunny.create_connection` (`bug_bunny.rb:87`) + `Session` |
+| auth | SASL user/pass (`username`/`password` de `Configuration`); URL `amqp://user:pass@host:port/vhost` |
+| ancla (doc proveedor) | Bunny: https://github.com/ruby-amqp/bunny · AMQP 0-9-1: https://www.rabbitmq.com/amqp-0-9-1-reference.html |
+
+### b. Operaciones consumidas (subset usado)
+
+| operación Bunny | dónde | qué mandamos / esperamos |
+|---|---|---|
+| `Bunny.new(opts).start` | `bug_bunny.rb:89,93` | abre `Bunny::Session` (conexión TCP + handshake); espera sesión iniciada |
+| `after_recovery_completed` | `bug_bunny.rb:90` | callback de recuperación de conexión → log `bug_bunny.connection_recovered` |
+| `session.create_channel` | `session.rb:177` (rescata fallo) | abre canal AMQP |
+| reconnect / recovery | `session.rb:285` | reconexión; en fallo → `CommunicationError` |
+| publish confirmado | `producer.rb:90` (`Producer#confirmed`) | `basic.publish` + publisher confirms; espera ACK/NACK |
+| publisher confirms (`nacked_set`) | `producer.rb:235` | lee NACKs del canal → `PublishNacked` |
+| `mandatory: true` + `basic.return` | `producer.rb:325` | mensaje no ruteable → `PublishUnroutable` (reply_code 312 NO_ROUTE) |
+| RPC (publish + reply-to consume) | `producer.rb:124,214` | request/response; timeout → `RequestTimeout` |
+| AMQP publish/consume genérico | `client.rb:168` | cualquier `Bunny::Exception` en la frontera → `CommunicationError` |
+
+> El mapa completo de operaciones que la gema **expone** (no las que consume)
+> es la capa operaciones (RFC-003, `docs/api/`, pendiente F2).
+
+### d. Errores del proveedor → excepción nuestra
+
+`bunny` levanta `Bunny::Exception` (y subclases). La gema las **envuelve** en la
+frontera de abstracción. La columna "excepción nuestra" **referencia** el
+catálogo `docs/errors/errors.md` (RFC-020), no lo redefine.
+
+| error del proveedor (Bunny) | excepción nuestra | dónde se mapea |
+|---|---|---|
+| `Bunny::Exception` (TCP fail, auth fail, vhost inválido) al conectar | `CommunicationError` | `bug_bunny.rb:95-98` |
+| `Bunny::Exception` al crear canal | `CommunicationError` | `session.rb:177` |
+| `Bunny::Exception` en reconexión | `CommunicationError` | `session.rb:285` |
+| `Bunny::Exception` en publish confirmado | `CommunicationError` | `producer.rb:90` |
+| `Bunny::Exception` / `ConnectionClosedError` en publish/consume | `CommunicationError` | `client.rb:168` |
+| NACK del broker (publisher confirms) | `PublishNacked` | `producer.rb:235` |
+| `basic.return` (mandatory, no ruteable) | `PublishUnroutable` | `producer.rb:325` |
+| timeout esperando reply RPC | `RequestTimeout` | `producer.rb:124,214` |
+
+> Regla: los callers no rescatan `Bunny::*` directo — `rescue
+> BugBunny::CommunicationError` cubre cualquier fallo de transporte/broker. La
+> original queda en `.cause`.
+
+### c / e. Enriquecimiento
+
+`—` (retry/idempotencia-semántica §c · degradación/qué pasa si RabbitMQ cae §e →
+`arch-enrich`, RFC-018).
+
+## 3. Inferencias
+
+- El gem declara **dependencia directa** solo de RabbitMQ-vía-bunny. Las demás
+  gemas del gemspec (`activemodel`, `activesupport`, `rack`, `json`,
+  `concurrent-ruby`, `ostruct`) son librerías de soporte, no sistemas externos
+  consumidos → van a topología (RFC-006), no acá.
+
+## 4. Cobertura y fronteras
+
+- §a/§b/§d **completas** al commit ancla; §c/§e sembrados `—`.
+- **`connection_pool` (`>= 2.4`):** utilidad de pooling de las conexiones Bunny
+  (`Resource.connection_pool`), **no** un sistema externo con su propio
+  contrato de error de red → no es entrada consumed; el timeout de pool
+  (`ConnectionPool::TimedStack`) nace dentro de `@pool.with` y termina envuelto
+  como `CommunicationError` (ver `CHANGELOG` #49). Pertenece a topología.
+- **Subset, no la API completa de Bunny:** solo se documentan las operaciones
+  que el gem invoca. Parámetros de tuning (heartbeat, prefetch, timeouts) viven
+  en `docs/config/`.

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -1,10 +1,10 @@
 # Errores — bug_bunny
 
-> meta: artefacto errores · RFC-020 (parte estructural) · generado `arch-structure`
-> · anclado a `5d7851a`, `lib/bug_bunny/exception.rb`, `remote_error.rb`,
-> `middleware/raise_error.rb`, `controller.rb`, `consumer.rb` · fecha 2026-06-30
-> · cobertura: §a/§b/§d completas (régimen estructura); §c sembrado `—`
-> (política → `arch-enrich`).
+> meta: artefacto errores · RFC-020 · generado `arch-structure` (§a/§b/§d) +
+> `arch-enrich` (§c) · anclado a `5d7851a`, `lib/bug_bunny/exception.rb`,
+> `remote_error.rb`, `middleware/raise_error.rb`, `controller.rb`, `consumer.rb`
+> · fecha 2026-06-30 · cobertura: §a/§b/§d completas (estructura); §c política
+> completa (enrich, **inferida** de HTTP/AMQP — verificación humana pendiente).
 
 ## 1. Resumen
 
@@ -89,7 +89,27 @@ operaciones de RFC-003 (`docs/api/`, hoy pendiente — ver §4), no las redefine
 
 ### c. Política por error
 
-`—` (sembrado · retriable/backoff/idempotencia/acción → `arch-enrich`, RFC-020 §c).
+Enriquecimiento `arch-enrich` (RFC-020 §c). Política **inferida** de semántica
+HTTP (RFC 9110) + AMQP — verificación humana pendiente (ver §3).
+
+| excepción | retriable | backoff | idempotencia | acción sugerida |
+|---|---|---|---|---|
+| `CommunicationError` | sí (fallo transitorio de red/broker) | sí (`network_recovery_interval`; Bunny auto-recover) | el retry de un **publish** puede duplicar salvo consumidor idempotente; un **read** RPC es seguro | reintentar con backoff; si persiste, circuit-break y alertar |
+| `ConfigurationError` | **no** (bug de config) | — | n/a | fail-fast al boot; corregir el bloque `configure` |
+| `SecurityError` | **no** | — | n/a | rechazar; investigar (posible intento de RCE por clase no autorizada) |
+| `PublishNacked` | sí, con cautela (NACK puede ser transitorio: disk full, replicación) | sí | el re-publish puede duplicar → requiere dedup aguas abajo | reintentar acotado; si persiste, alertar (problema del broker) |
+| `PublishUnroutable` | **no** (no hay binding para la routing key) | — | n/a | corregir routing key / topología de bindings; alertar (mensaje perdido) |
+| `BadRequest` (400) | **no** | — | n/a | corregir el request del cliente |
+| `NotFound` (404) | **no** | — | n/a | verificar recurso/identificador |
+| `RoutingError` (404) | **no** | — | n/a | corregir verbo/path; el servicio remoto no tiene esa ruta registrada |
+| `NotAcceptable` (406) | **no** | — | n/a | corregir content negotiation |
+| `RequestTimeout` (408) | sí (transitorio) | sí | el retry de un publish/RPC mutante puede duplicar → idempotencia requerida | reintentar con backoff; subir `rpc_timeout` si es crónico |
+| `Conflict` (409) | **no** sin resolver el conflicto | — | depende del flujo | resolver el estado en conflicto antes de reintentar |
+| `UnprocessableEntity` (422) | **no** (error semántico/validación) | — | n/a | corregir el payload; leer `error_messages` / `raw_response` |
+| `ClientError` (4xx genérico) | **no** (default 4xx) | — | n/a | inspeccionar status concreto |
+| `ServerError` (5xx genérico) | sí (transitorio) | sí | idempotencia requerida si la op muta estado | reintentar con backoff |
+| `InternalServerError` (500) | sí (transitorio) | sí | idem | reintentar con backoff; si persiste, escalar al dueño del worker |
+| `RemoteError` (500) | depende de `original_class` | depende | depende | inspeccionar `original_class`/`original_backtrace`; tratar como bug del worker remoto, no reintentar a ciegas |
 
 ### d. Shape del payload de error
 
@@ -151,6 +171,13 @@ parsea el body, devuelve `parsed['errors']` por convención o el cuerpo completo
 - **§b superficies AMQP** (`PublishNacked`/`PublishUnroutable`/`CommunicationError`)
   no tienen status HTTP: son señales del protocolo AMQP, no del envelope RPC. Se
   listan como `n/a (AMQP)` para no forzar un código HTTP inventado.
+- **§c política (enrich):** la columna retriable/backoff/idempotencia/acción está
+  **inferida** de la semántica estándar (HTTP RFC 9110 para 4xx/5xx, comportamiento
+  AMQP para NACK/return/transporte), **no** de una política declarada en el código
+  del gem. `confidence: medium`. A confirmar con el dueño del código /
+  consumidores reales (sobre todo idempotencia de re-publish y el caso
+  `RemoteError`, que depende del `original_class` del worker). El gem **no impone**
+  retry: la decisión es del consumidor en su boundary.
 
 ## 4. Cobertura y fronteras
 

--- a/docs/test/test.md
+++ b/docs/test/test.md
@@ -1,0 +1,81 @@
+# Test — bug_bunny
+
+> meta: artefacto test · RFC-013 (estructural §a/§b/§c/§d) · generado
+> `arch-structure` · anclado a `5eea236`, `Rakefile`, `bug_bunny.gemspec`,
+> `spec/spec_helper.rb`, `.github/workflows/main.yml` · fecha 2026-06-30 ·
+> cobertura: §a/§b/§c/§d completas; §e gaps · §f contract-assessment · §g
+> link-incidente · §h PII sembrados `—` (→ `arch-enrich`).
+
+## 1. Resumen
+
+Suite principal **RSpec** (`spec/`, 22 specs: 15 unit + 7 integration). Tarea
+`:test` legacy de **Minitest** (`test/`, 2 archivos) fuera del default y del CI.
+CI corre `bundle exec rake` (= `:spec`) en Ruby 3.4.4. Sin coverage tool
+configurado.
+
+## 2. Cuerpo
+
+### a. Suites, frameworks y niveles
+
+| framework | dir | nivel | nº | propósito |
+|---|---|---|---|---|
+| **RSpec** `~> 3.0` | `spec/unit/` | unit | 15 | client/session pool, configuration, consumer, producer, controller, raise_error, remote_error, request, route, observability, otel, resource, middleware |
+| **RSpec** | `spec/integration/` | integration | 7 | client, consumer_middleware, controller, error_handling, infrastructure, publisher_confirms, resource — **requieren RabbitMQ real** (usan `BugBunny.create_connection` + pool) |
+| **Minitest** `~> 5.0` (+ `mocha`, `minitest-reporters`) | `test/integration/` | integration (legacy) | 2 | `manual_client_test.rb`, `infrastructure_test.rb` — tarea `:test`, **no** en default ni CI |
+
+Sin tags declarados (`:slow`/`:js`) en la config de RSpec.
+
+### b. Comando de corrida
+
+| objetivo | comando | qué corre |
+|---|---|---|
+| default / CI | `bundle exec rake` | tarea `:spec` (toda la suite RSpec) — `Rakefile:` `task default: :spec` |
+| solo unit | `bundle exec rake spec:unit` | `spec/unit/**/*_spec.rb` |
+| solo integration | `bundle exec rake spec:integration` | `spec/integration/**/*_spec.rb` (requiere broker) |
+| Minitest legacy | `bundle exec rake test` | `test/**/*_test.rb` |
+| CI | `.github/workflows/main.yml` → `bundle exec rake` | matrix Ruby `3.4.4`, `ruby/setup-ruby@v1` + `bundler-cache`, on push `master` + PR |
+
+> Todas las tareas RSpec corren con `--require spec_helper` (`Rakefile`).
+
+### c. Fixtures / Factories
+
+- **Sin FactoryBot ni fixtures YAML.** El setup vive en `spec/spec_helper.rb`:
+  configura `BugBunny` (host/user/pass desde ENV con default `guest`), arma un
+  `ConnectionPool` de test (`TEST_POOL`, size 5) y declara rutas globales para
+  todos los specs (`resources :ping/:node/:user`, `get 'around'/'rescue'/'boom'/
+  'echo'`, `post 'events'`).
+- **Carga `.env`** si existe (parse manual, `spec_helper.rb`).
+- **Soporte:** `spec/support/integration_helper.rb` (helpers + `TEST_WORKER_QUEUE_OPTS`
+  para colas efímeras), `spec/support/bunny_mocks.rb` (mocks de Bunny para unit).
+- `exchange_options = { durable: false, auto_delete: true }` → exchanges efímeros
+  en test.
+
+### d. Configuración de coverage
+
+**n/a** — sin SimpleCov ni `.simplecov` ni `SimpleCov.start` en el repo. No hay
+umbral de coverage declarado.
+
+### e/f/g/h. Enriquecimiento
+
+`—` (gaps de cobertura · contract-assessment de RFC-003/018/020 · link a
+incidente del que nació un test de regresión · PII en fixtures → `arch-enrich`,
+RFC-013).
+
+## 3. Inferencias
+
+- **Doble framework:** RSpec es el primario (default + CI); Minitest (`test/`,
+  `mocha`, `minitest-reporters` en gemspec) es **legacy** — el comentario del
+  `Rakefile` lo declara explícito ("tests de integración legacy de Minitest").
+  `confidence: high`.
+- **CI on `master`** (`main.yml`: `push: branches: [master]`) pero la rama
+  principal del repo es `main` → el trigger `push` no dispara en `main`; el CI
+  efectivo entra por `pull_request`. Posible drift de naming master/main. A
+  verificar con el dueño. `confidence: medium`.
+
+## 4. Cobertura y fronteras
+
+- §a/§b/§c/§d **completas** al commit ancla; §e-§h sembrados `—`.
+- **Integration specs requieren un RabbitMQ vivo** — no corren aislados sin
+  broker. La evaluación de qué contratos públicos (RFC-003/018/020) cubren los
+  tests es §f, fuera de structure.
+- **Contenido de cada test case** queda en el código, no se inventaria acá.


### PR DESCRIPTION
## Contexto

Auditoría post-PR #54: quedaban capas con gatillo presente pero sin generar ni declarar. Este PR las completa y deja el índice honesto. Verificado con `critias --pr --full`: **0 errores, 0 warnings, 3 info** (2 ya corregidos en este PR).

## Capas nuevas (arch-structure, ancladas a `5eea236`)

| capa | RFC | contenido |
|---|---|---|
| `docs/config/configuracion.md` | RFC-012 | inventario base de las 29 opciones de `Configuration` + defaults, §c meta-template ENV sugeridas al consumidor, §d derivaciones (`url`/merge), §i inyecciones del `Railtie` |
| `docs/consumed/rabbitmq.md` | RFC-018 | RabbitMQ-vía-`bunny`: §a identidad, §b operaciones AMQP consumidas, §d mapeo `Bunny::Exception`→excepción nuestra (referencia `docs/errors/`) |
| `docs/test/test.md` | RFC-013 | suite RSpec (15 unit + 7 integration) + Minitest legacy, comandos rake, CI Ruby 3.4.4, fixtures vía `spec_helper` |

## Enriquecimiento (arch-enrich)

- `docs/errors/errors.md` §c: política retriable/backoff/idempotencia/acción por excepción, **inferida** de HTTP RFC 9110 + AMQP (`confidence: medium`, verificación humana pendiente — el gem no impone retry).

## Compuestos / índice

- `AGENTS.md` **nuevo**: stanza "Mapa de conocimiento" (RFC-008 r2) que indexa las 7 capas presentes + declara n/a las no aplicables (data/events/security/multi-tenancy/data-lifecycle). Cierra STRUCT-003.
- `CLAUDE.md`: índice de capas reescrito al estado real.

## ⚠️ Inferencias marcadas para verificación humana
- `errors §c` política (HTTP/AMQP).
- `config`: `requerida=sí` de host/port/user/pass/vhost (`validate!` no-vacío, con default).
- `test`: CI en `master` pero la rama principal es `main` → posible drift de naming.
- `SecurityError` sin raise-site localizado en `lib/` (heredado de #54).

## Fuera de alcance (otro PR)
- operaciones/interfaz/topología (RFC-003/004/006) = dev-structure F2.
- Resto del enrich: config §f/g/h/j, consumed §c/§e, test §e-§h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)