### PR TITLE
docs(enrich): completar enriquecimiento de config/consumed/test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ proyecto y convenciones de equipo, ver `CLAUDE.md`. Para la entrada humana, ver
 | Comportamiento | `docs/behavior/behavior.md` | completo (6 flujos) | secuencias de publish/RPC/consume/confirms, contrato de error-wrapping |
 | Glosario | `docs/glossary/glossary.md` | parcial (acreta por PR) | término de negocio → binding físico en `lib/` |
 | Errores | `docs/errors/errors.md` | completo (§a/b/d estructura + §c política inferida) | jerarquía de excepciones públicas, mapeo `status→excepción`, shape del payload, política retry |
-| Configuración | `docs/config/configuracion.md` | inventario base completo | opciones de `Configuration`, defaults, inyecciones del `Railtie`, ENV sugeridas al consumidor |
-| Dependencias consumidas | `docs/consumed/rabbitmq.md` | §a/b/d completo | qué consume del broker RabbitMQ vía `bunny`, mapeo error-Bunny→excepción |
-| Test | `docs/test/test.md` | estructura completa | suites RSpec/Minitest, comandos, CI, fixtures |
+| Configuración | `docs/config/configuracion.md` | completo (estructura + enrich §f/g/h) | opciones de `Configuration`, defaults, failure-mode/threading, inyecciones del `Railtie`, ENV sugeridas |
+| Dependencias consumidas | `docs/consumed/rabbitmq.md` | completo (estructura + enrich §c/e) | qué consume del broker RabbitMQ vía `bunny`, mapeo error-Bunny→excepción, retry/degradación |
+| Test | `docs/test/test.md` | completo (estructura + enrich §e-h) | suites RSpec/Minitest, CI, contract-assessment, link a incidentes (#49/#52) |
 | Release | `docs/release/release.md` | completo | patrón gema-tag, versionado, publish a RubyGems |
 | Datos | — | n/a | gema sin DB |
 | Operaciones / Interfaz / Topología | — | dev-structure F2 no implementado | contrato embebido en `README.md`/`skill/SKILL.md` (interim RFC-008 §2) |
@@ -26,12 +26,13 @@ proyecto y convenciones de equipo, ver `CLAUDE.md`. Para la entrada humana, ver
 | Multi-tenancy (RFC-023) | — | n/a | sin modelo de tenant propio; el aislamiento es por `vhost` de RabbitMQ (config) |
 | Data-lifecycle (RFC-026) | — | n/a | gema sin DB ni datos persistidos propios |
 
-## Enriquecimiento pendiente (`arch-enrich`)
+## Enriquecimiento
 
-- `docs/errors/errors.md` §c — política inferida de HTTP/AMQP, falta confirmar con dueño.
-- `docs/config/configuracion.md` §f/§g/§h/§j — semántica/failure-mode/threading.
-- `docs/consumed/rabbitmq.md` §c/§e — retry/idempotencia + degradación si RabbitMQ cae.
-- `docs/test/test.md` §e-§h — gaps de cobertura, contract-assessment, link a incidente, PII.
+Completo en errors (§c), config (§f/g/h), consumed (§c/e) y test (§e-h), anclado
+a YARD/specs/CHANGELOG. Pendiente de **verificación humana** (inferencias):
+
+- `docs/errors/errors.md` §c — política retry inferida de HTTP/AMQP (`confidence:medium`); confirmar idempotencia de re-publish y caso `RemoteError` con consumidores reales.
+- `docs/glossary/glossary.md` — parcial por diseño, acreta por PR.
 
 ## Convenciones operativas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,12 @@ BugBunny es una gema Ruby que implementa una capa de enrutamiento RESTful sobre 
   - `docs/glossary` parcial (acreta por PR).
   - `docs/errors` (RFC-020) completo: §a/§b/§d (estructura) + §c política
     (enrich, **inferida** de HTTP/AMQP, verificación humana pendiente).
-  - `docs/config` (RFC-012) inventario base completo (§a-§e/§i); enriquecimiento
-    semántico (§f/§g/§h/§j) pendiente de `arch-enrich`.
-  - `docs/consumed` (RFC-018) RabbitMQ-vía-`bunny`: §a/§b/§d completo; §c/§e
-    (retry/degradación) pendiente de `arch-enrich`.
-  - `docs/test` (RFC-013) estructura completa (§a-§d); §e-§h (gaps/contract/
-    incidente/PII) pendiente de `arch-enrich`.
+  - `docs/config` (RFC-012) completo: inventario §a-§e/§i + enrich §f/§g/§h
+    (failure-mode/threading, anclado a YARD); §j n/a.
+  - `docs/consumed` (RFC-018) RabbitMQ-vía-`bunny` completo: §a/§b/§d + enrich
+    §c/§e (retry/backoff/degradación, anclado a `consumer.rb`).
+  - `docs/test` (RFC-013) completo: estructura §a-§d + enrich §e-§h
+    (contract-assessment, link a incidentes #49/#52, gaps de CI).
   - operaciones/interfaz/topología (RFC-003/004/006) = dev-structure F2 no
     implementado (interim RFC-008 §2).
 - **Para agentes AI**: `skill/SKILL.md` (empaquetada en el `.gem`) +

--- a/docs/config/configuracion.md
+++ b/docs/config/configuracion.md
@@ -1,11 +1,12 @@
 # Configuración — bug_bunny
 
-> meta: artefacto configuración · RFC-012 (inventario base shape v2.2) · generado
-> `arch-structure` · anclado a `5eea236`, `lib/bug_bunny/configuration.rb`,
-> `lib/bug_bunny.rb`, `lib/bug_bunny/railtie.rb`,
+> meta: artefacto configuración · RFC-012 · generado `arch-structure` (inventario
+> §a-§e/§i) + `arch-enrich` (§f/§g/§h/§j) · anclado a `24ea397`,
+> `lib/bug_bunny/configuration.rb`, `lib/bug_bunny.rb`, `lib/bug_bunny/railtie.rb`,
+> `lib/bug_bunny/consumer.rb`,
 > `lib/generators/bug_bunny/install/templates/initializer.rb` · fecha 2026-06-30
-> · cobertura: §a/§b/§c/§d/§e/§i completas; enriquecimiento (§f categoría/
-> failure-mode/side-effect, §g/§h/§j) sembrado `—` (→ `arch-enrich`).
+> · cobertura: §a-§e/§i (estructura) + §f/§g/§h (enrich, anclado a YARD) completas;
+> §j n/a.
 
 ## 1. Resumen
 
@@ -105,11 +106,48 @@ El install template (`initializer.rb`) **sugiere al consumidor** wirear 4 ENV
 | `rake_tasks` | carga `tasks/bug_bunny.rake` (`bug_bunny:sync`) | `:38-40` |
 | `Spring.after_fork` | cierra conexión en preloader Spring | `:43-47` |
 
-### f/g/h/j. Enriquecimiento
+### f. Enriquecimiento semántico
 
-`—` (categoría · failure-mode · side-effect · scope-override · business-reason ·
-ramificadores intra-config · threading · mapeo de inyección a gemas →
-`arch-enrich`, RFC-012).
+Agrupado por familia. Anclado a los YARD de `configuration.rb` y al comportamiento
+del código.
+
+| familia | categoría | failure-mode | side-effect | business-reason |
+|---|---|---|---|---|
+| Conexión (`host`/`port`/`username`/`password`/`vhost`) | conectividad | valor inválido/vacío → `ConfigurationError` en `validate!`; credencial/host errados → `CommunicationError` al conectar (`bug_bunny.rb:95`) | abre socket TCP al broker | identidad y destino del broker; `vhost` aísla ambientes |
+| Timeouts (`connection_timeout`/`read_timeout`/`write_timeout`/`heartbeat`/`continuation_timeout`) | resiliencia/latencia | muy bajo → cortes espurios bajo carga; muy alto → detección de fallo lenta | — | tuning de la conexión Bunny; `heartbeat` detecta conexiones zombi |
+| `rpc_timeout` | latencia | el worker remoto no responde a tiempo → `RequestTimeout` (`producer.rb:124,214`) | bloquea el hilo llamante hasta el timeout | techo de espera de un RPC síncrono |
+| Resiliencia (`automatically_recover`/`network_recovery_interval`/`max_reconnect_attempts`/`max_reconnect_interval`) | resiliencia | `max_reconnect_attempts` agotado → el Consumer re-levanta y muere (`consumer.rb:110-112`) | reintentos con **backoff exponencial** `network_recovery_interval * 2^(n-1)` cap `max_reconnect_interval` (`consumer.rb:115-118`) | sobrevivir caídas transitorias del broker sin perder el worker |
+| QoS (`channel_prefetch`) | rendimiento | alto → un worker lento acapara mensajes; `1` → menor throughput | controla unacked in-flight (backpressure) | balancea fairness vs throughput (default `1` = fair round-robin) |
+| Health (`health_check_interval`/`health_check_file`) | observabilidad | `health_check_file` no escribible → el touch falla (degradación de visibilidad, no del flujo) | **escribe (touch) un archivo** en cada health check OK; `nil` desactiva | probe para orquestadores (K8s/Swarm) |
+| Callbacks (`on_return`/`on_rpc_reply`/`rpc_reply_headers`) | extensibilidad | una excepción en `on_return` se captura pero **degrada visibilidad** (YARD `configuration.rb:147`) | corren en hilos sensibles (ver §h) | propagar trace-context / alertar unroutable |
+| Confirms (`nack_raise`/`return_raise`) | integridad de entrega | `false` → NACK/return solo se logea, la llamada retorna `202` (modo legacy, posible pérdida silenciosa) | habilitan el raise de `PublishNacked`/`PublishUnroutable` | elegir entre fail-fast vs best-effort en publish confirmado |
+| Routing (`controller_namespace`) | seguridad | clase fuera del namespace/herencia → `SecurityError` (anti-RCE) | acota qué clases son enrutables | superficie de control de RCE |
+| Logging (`logger`/`bunny_logger`/`log_tags`) | observabilidad | — | salida a `$stdout` por default | trazabilidad estructurada |
+| Infra (`exchange_options`/`queue_options`) | infraestructura | options incompatibles con el broker → `PreconditionFailed` (vía `CommunicationError`) | defaults globales mergeados por recurso | declaración AMQP por default |
+
+### g. Ramificadores intra-config
+
+- `health_check_file = nil` (default) **desactiva** el touchfile aunque
+  `health_check_interval` siga corriendo (`configuration.rb:99-101,207`).
+- `return_raise` es **inerte cuando `mandatory: false`** — sin `mandatory` el
+  broker nunca retorna, así que el flag no tiene efecto (`configuration.rb:171`).
+- `nack_raise`/`return_raise` se sobreescriben **por request** (`Client#publish`),
+  ganando sobre el valor global (scope-override).
+
+### h. Threading
+
+| opción | hilo de ejecución | restricción |
+|---|---|---|
+| `on_return` | **hilo interno del consumidor de Bunny** (`configuration.rb:147`) | debe ser rápido y no lanzar; BugBunny captura, pero degrada visibilidad |
+| `on_rpc_reply` | **hilo llamante** tras recibir el reply RPC (`configuration.rb:132`) | hidrata trace-context en el publisher |
+| `rpc_reply_headers` | hilo del consumer, justo antes del `basic_publish` del reply (`configuration.rb:125`) | debe retornar un Hash de headers |
+| reconexión del Consumer | hilo del `subscribe` loop (`consumer.rb:90,122`) | `sleep wait` bloquea ese hilo durante el backoff |
+
+### j. Inyección a gemas configuradas
+
+**n/a** — la gema **no** configura otras gemas vía bloque `Gema.configure` en
+initializers; expone su propio `BugBunny.configure`. El `Railtie` inyecta al
+host (§i), no a gemas terceras.
 
 ## 3. Inferencias
 
@@ -122,12 +160,13 @@ ramificadores intra-config · threading · mapeo de inyección a gemas →
 
 ## 4. Cobertura y fronteras
 
-- §a/§b/§c/§d/§e/§i **completas** al commit ancla; enriquecimiento sembrado `—`.
+- §a-§e/§i (estructura) + §f/§g/§h (enrich) **completas** al commit ancla; §j n/a.
 - **Linter de secretos (advisory):** `password` default `'guest'` y el template
   `RABBITMQ_PASSWORD` default `'guest'` matchean el patrón de secreto, pero el
   valor es el placeholder default de RabbitMQ, **no** un secreto hardcodeado. El
   consumidor debe inyectar la credencial real vía ENV en prod (lo dice el header
   del template). No es hallazgo de fuga.
-- **Fuera de alcance:** la semántica de cada timeout/flag (qué falla si se
-  setea mal, side-effects de threading de los callbacks `on_return`/
-  `on_rpc_reply` que corren en el hilo del consumidor de Bunny) → `arch-enrich`.
+- **Enriquecimiento (§f/§g/§h):** anclado a los YARD de `configuration.rb` y al
+  backoff real de `consumer.rb` — no inventado. La elección de valores concretos
+  (tuning de timeouts/prefetch por ambiente) es decisión operativa del consumidor,
+  no del artefacto.

--- a/docs/consumed/rabbitmq.md
+++ b/docs/consumed/rabbitmq.md
@@ -1,11 +1,11 @@
 # Dependencia consumida: RabbitMQ (vía `bunny`) — bug_bunny
 
-> meta: artefacto consumed · RFC-018 (estructural §a/§b/§d) · generado
-> `arch-structure` · anclado a `5eea236`, `bug_bunny.gemspec`,
+> meta: artefacto consumed · RFC-018 · generado `arch-structure` (§a/§b/§d) +
+> `arch-enrich` (§c/§e) · anclado a `24ea397`, `bug_bunny.gemspec`,
 > `lib/bug_bunny.rb`, `lib/bug_bunny/session.rb`, `lib/bug_bunny/producer.rb`,
-> `lib/bug_bunny/middleware/raise_error.rb` · fecha 2026-06-30 · cobertura:
-> §a/§b/§d completas; §c (retry/idempotencia) y §e (degradación) sembrados `—`
-> (→ `arch-enrich`).
+> `lib/bug_bunny/consumer.rb`, `lib/bug_bunny/middleware/raise_error.rb` · fecha
+> 2026-06-30 · cobertura: §a/§b/§d (estructura) + §c/§e (enrich, anclado a
+> `consumer.rb`) completas.
 
 ## 1. Resumen
 
@@ -65,10 +65,22 @@ catálogo `docs/errors/errors.md` (RFC-020), no lo redefine.
 > BugBunny::CommunicationError` cubre cualquier fallo de transporte/broker. La
 > original queda en `.cause`.
 
-### c / e. Enriquecimiento
+### c. Retry / idempotencia
 
-`—` (retry/idempotencia-semántica §c · degradación/qué pasa si RabbitMQ cae §e →
-`arch-enrich`, RFC-018).
+| aspecto | comportamiento (anclado) |
+|---|---|
+| recuperación de conexión | `automatically_recover = true` (default): Bunny recupera canales/suscripciones tras corte TCP (`configuration.rb:60-61`). |
+| retry del Consumer | `Consumer#subscribe` reintenta en cualquier `StandardError` con **backoff exponencial** `network_recovery_interval * 2^(n-1)` cap `max_reconnect_interval`, hasta `max_reconnect_attempts` (`nil` = ∞) (`consumer.rb:106-124`). |
+| ack | `manual_ack: true` (`consumer.rb:90`) → entrega **at-least-once**: si el worker cae tras procesar pero antes del ack, el mensaje se re-entrega. **El handler debe ser idempotente.** |
+| retry de publish | **no automático** — un publish fallido levanta `CommunicationError`/`PublishNacked`; reintentarlo puede **duplicar** salvo dedup aguas abajo. |
+| RPC | `request` espera reply hasta `rpc_timeout`; el retry de un RPC mutante requiere idempotencia (correlación por `correlation_id`). |
+
+### e. Degradación (si RabbitMQ cae)
+
+- **Al conectar:** `create_connection` levanta `CommunicationError` (`bug_bunny.rb:95`); no hay fallback ni cola local — el caller decide (circuit-break/alertar).
+- **Consumer:** entra al loop de reconexión con backoff; por default (`max_reconnect_attempts = nil`) **reintenta indefinidamente**, logueando `consumer.connection_error` con `retry_in_s` (`consumer.rb:120-122`). Si se fija un máximo y se agota → `consumer.reconnect_exhausted` y re-raise (el worker muere).
+- **Publisher:** cada publish/RPC sobre conexión caída levanta `CommunicationError` (envuelto en `client.rb:168`); **sin buffering** — el mensaje no sale.
+- **Sin circuit-breaker propio:** la gema no trae breaker ni outbox; la resiliencia aguas arriba (reintentar el comando, encolar, alertar) es responsabilidad del consumidor.
 
 ## 3. Inferencias
 
@@ -79,7 +91,7 @@ catálogo `docs/errors/errors.md` (RFC-020), no lo redefine.
 
 ## 4. Cobertura y fronteras
 
-- §a/§b/§d **completas** al commit ancla; §c/§e sembrados `—`.
+- §a/§b/§d (estructura) + §c/§e (enrich, anclado a `consumer.rb`) **completas**.
 - **`connection_pool` (`>= 2.4`):** utilidad de pooling de las conexiones Bunny
   (`Resource.connection_pool`), **no** un sistema externo con su propio
   contrato de error de red → no es entrada consumed; el timeout de pool

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -181,15 +181,15 @@ parsea el body, devuelve `parsed['errors']` por convención o el cuerpo completo
 
 ## 4. Cobertura y fronteras
 
-- **§a/§b/§d completas** al commit ancla; **§c sembrado `—`** (política →
-  `arch-enrich`).
+- **§a/§b/§d (estructura) + §c (enrich, política inferida) completas** al commit
+  ancla. §c marcada `confidence: medium` (ver §3).
 - **RFC-003 (`docs/api/`) pendiente:** §b referencia "superficie" de operaciones
   pero la capa operaciones no está generada (dev-structure F2, ver `CLAUDE.md`).
   Cuando se genere, §b debe cruzar las operaciones reales.
 - **Frontera con `consumed` (RFC-018):** este artefacto = errores que la gema
   **emite**. Los errores de `Bunny::*` que la gema **consume** y envuelve en
-  `CommunicationError` son su mapeo error-proveedor→excepción; viven del lado
-  consumed (capa no generada — la gema consume `bunny`/`connection_pool`).
+  `CommunicationError` son su mapeo error-proveedor→excepción; viven en
+  `docs/consumed/rabbitmq.md` §d (que referencia este catálogo, no lo redefine).
 - **Errores internos no-públicos** (rescatados adentro, no cruzan la frontera) y
   los `ArgumentError`/`NameError` de mal-uso de la API de config quedan fuera:
   no son contrato runtime.

--- a/docs/test/test.md
+++ b/docs/test/test.md
@@ -1,10 +1,10 @@
 # Test — bug_bunny
 
-> meta: artefacto test · RFC-013 (estructural §a/§b/§c/§d) · generado
-> `arch-structure` · anclado a `5eea236`, `Rakefile`, `bug_bunny.gemspec`,
-> `spec/spec_helper.rb`, `.github/workflows/main.yml` · fecha 2026-06-30 ·
-> cobertura: §a/§b/§c/§d completas; §e gaps · §f contract-assessment · §g
-> link-incidente · §h PII sembrados `—` (→ `arch-enrich`).
+> meta: artefacto test · RFC-013 · generado `arch-structure` (§a-§d) +
+> `arch-enrich` (§e-§h) · anclado a `24ea397`, `Rakefile`, `bug_bunny.gemspec`,
+> `spec/spec_helper.rb`, `spec/support/integration_helper.rb`,
+> `.github/workflows/main.yml`, `CHANGELOG.md` · fecha 2026-06-30 · cobertura:
+> §a-§d (estructura) + §e-§h (enrich, anclado a specs/CHANGELOG) completas.
 
 ## 1. Resumen
 
@@ -55,11 +55,42 @@ Sin tags declarados (`:slow`/`:js`) en la config de RSpec.
 **n/a** — sin SimpleCov ni `.simplecov` ni `SimpleCov.start` en el repo. No hay
 umbral de coverage declarado.
 
-### e/f/g/h. Enriquecimiento
+### e. Gaps de cobertura
 
-`—` (gaps de cobertura · contract-assessment de RFC-003/018/020 · link a
-incidente del que nació un test de regresión · PII en fixtures → `arch-enrich`,
-RFC-013).
+- **Integration specs no corren en CI:** `main.yml` no declara servicio RabbitMQ;
+  las 7 integration specs **se skipean** vía `rabbitmq_available?`
+  (`spec/support/integration_helper.rb:14`, ver `publisher_confirms_spec.rb:10`).
+  En CI solo se ejercitan las **15 unit specs** → el contrato AMQP real (publish/
+  consume/confirms contra broker) **no se valida en pipeline**, solo localmente
+  con broker. Gap relevante.
+- **Sin medición de cobertura:** no hay SimpleCov ni umbral → la cobertura no está
+  cuantificada (no se sabe el % de líneas ejercidas).
+
+### f. Contract-assessment
+
+¿Los tests cubren los contratos públicos? (RFC-020/018/012/003)
+
+| contrato | specs que lo cubren | veredicto |
+|---|---|---|
+| **Errores RFC-020** (status→excepción, materia prima) | `raise_error_spec`, `remote_error_spec`, `communication_error_wrapping_spec`, `error_handling_spec` (integration) | **bien cubierto** (unit) |
+| **Consumed RFC-018** (Bunny::Exception→`CommunicationError`) | `communication_error_wrapping_spec`, `client_session_pool_spec` | cubierto (unit) |
+| **Config RFC-012** (validaciones de `Configuration`) | `configuration_spec` | cubierto |
+| **Confirms** (`PublishNacked`/`PublishUnroutable`) | `producer_spec`, `publisher_confirms_spec` (integration) | parcial en CI (la parte integration skipea sin broker) |
+| **Operaciones/routing** (RFC-003, capa F2) | `route_spec`, `request_spec`, `controller_spec`, `controller_after_action_spec`, `resource_spec` | cubierto (unit) |
+
+### g. Link a incidente → test de regresión
+
+| incidente | test de regresión | ancla |
+|---|---|---|
+| **#52** (`status`/`raw_response` en toda la jerarquía + hardening de `format_error_message`) | `raise_error_spec` — comentarios explícitos "Alcance issue #52" | `spec/unit/raise_error_spec.rb:59,120,169` |
+| **#49** (leak de `Bunny::TCPConnectionFailedForAllHosts` en `try_create`) | `communication_error_wrapping_spec` — "Client#publish — TCP fail en try_create (issue #49 caso original)" | `spec/unit/communication_error_wrapping_spec.rb:41` |
+
+### h. PII en fixtures / factories
+
+- **Sin PII.** No hay fixtures con datos personales: `spec_helper` usa
+  placeholders (`guest`/`localhost`), las rutas de test son `ping`/`node`/`user`
+  **sin payloads de datos reales**, y `bunny_mocks.rb` mockea el driver. Cruza
+  RFC-026: nada que clasificar/anonimizar. `confidence: high`.
 
 ## 3. Inferencias
 
@@ -73,8 +104,7 @@ RFC-013).
 
 ## 4. Cobertura y fronteras
 
-- §a/§b/§c/§d **completas** al commit ancla; §e-§h sembrados `—`.
-- **Integration specs requieren un RabbitMQ vivo** — no corren aislados sin
-  broker. La evaluación de qué contratos públicos (RFC-003/018/020) cubren los
-  tests es §f, fuera de structure.
+- §a-§d (estructura) + §e-§h (enrich, anclado a specs/CHANGELOG) **completas**.
+- **Integration specs requieren un RabbitMQ vivo** y se skipean sin broker (§e) —
+  por eso no se ejercitan en CI.
 - **Contenido de cada test case** queda en el código, no se inventaria acá.


### PR DESCRIPTION
## Contexto

Completa el **enriquecimiento** (`arch-enrich`) de las 3 capas estructurales generadas en #55, anclado a YARD/código/specs/CHANGELOG (no inventado). Verificado con `critias --pr --full`: **0 errores, 0 warnings, 3 info** (2 confirmatorios, 1 preexistente ya corregido en este PR).

## Cambios

| capa | secciones enrich | anclaje |
|---|---|---|
| `docs/config/configuracion.md` | §f semántica por familia (categoría/failure-mode/side-effect/business-reason), §g ramificadores, §h threading; §j n/a | YARD de `configuration.rb` + backoff de `consumer.rb` |
| `docs/consumed/rabbitmq.md` | §c retry/idempotencia (backoff exp., at-least-once por `manual_ack`), §e degradación (sin circuit-breaker propio) | `consumer.rb:106-124` |
| `docs/test/test.md` | §e gaps (integration specs skipean en CI sin broker → solo unit corre), §f contract-assessment RFC-020/018/012/003, §g link a incidentes, §h PII | specs + `CHANGELOG` |

**Link a incidente (§g), anclado a comentarios reales de los specs:**
- #52 → `raise_error_spec.rb:59,120,169` ("Alcance issue #52").
- #49 → `communication_error_wrapping_spec.rb:41` ("issue #49 caso original").

**Índices:** `AGENTS.md` + `CLAUDE.md` reflejan enrich completo.
**Bonus:** reconcilia `errors.md` §4 (refs stale "§c sembrado —" y "consumed no generada").

## ⚠️ Verificación humana pendiente (declarada, no bloqueante)
- `errors §c` política HTTP/AMQP (`confidence:medium`): confirmar idempotencia de re-publish + caso `RemoteError`.
- `glossary`: parcial por diseño (acreta por PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)