### PR TITLE
chore(errors): eliminar BugBunny::SecurityError (dead code) + ajustar doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ proyecto y convenciones de equipo, ver `CLAUDE.md`. Para la entrada humana, ver
 | Datos | — | n/a | gema sin DB |
 | Operaciones / Interfaz / Topología | — | dev-structure F2 no implementado | contrato embebido en `README.md`/`skill/SKILL.md` (interim RFC-008 §2) |
 | Eventos (RFC-005) | — | n/a | la gema es el transporte de eventos, no declara un catálogo de eventos de dominio propio |
-| Seguridad (RFC-017) | — | n/a | sin authn/authz propias; el único control es `SecurityError` (validación de herencia de controladores), cubierto en `docs/errors/` |
+| Seguridad (RFC-017) | — | n/a | sin authn/authz propias; el único control es el guard anti-RCE (clase enrutada debe heredar de `BugBunny::Controller`, si no → 403), cubierto en `docs/errors/` |
 | Multi-tenancy (RFC-023) | — | n/a | sin modelo de tenant propio; el aislamiento es por `vhost` de RabbitMQ (config) |
 | Data-lifecycle (RFC-026) | — | n/a | gema sin DB ni datos persistidos propios |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+> Limpieza de dead code. **Breaking en sentido estricto** (se elimina una constante pública), pero **funcionalmente inerte**: la clase nunca se levantaba. Definir el bump al release.
+
+### Removed
+- **`BugBunny::SecurityError` eliminada (dead code):** la clase estaba definida y documentada como el control anti-RCE, pero **ninguna ruta de código la levantaba**. La protección real (clase enrutada debe heredar de `BugBunny::Controller`) ya existe en `Consumer` y responde **403 Forbidden** + reject + log `consumer.security_violation`, no una excepción. Un `rescue BugBunny::SecurityError` en un consumidor era código muerto (la excepción nunca se disparaba). Doc ajustada (`docs/errors/`, README, skill). — @Gabriel
+
 ## [4.19.0] - 2026-06-25
 
 > Capa de errores transport-agnostic (#52). Cambio **aditivo y retrocompatible**: `.message` no se degrada y se suman dos accesores. Bump minor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [Unreleased]
 
-> Limpieza de dead code. **Breaking en sentido estricto** (se elimina una constante pública), pero **funcionalmente inerte**: la clase nunca se levantaba. Definir el bump al release.
+> **BREAKING — requiere bump MAJOR.** Se elimina la constante pública `BugBunny::SecurityError`. Aunque la excepción nunca se *levantaba*, su **ausencia rompe en evaluación**: un `rescue BugBunny::SecurityError` en un consumidor resuelve la constante cuando *cualquier* excepción entra a ese bloque → `NameError` que enmascara la excepción original. Por eso es breaking real, no inerte.
 
 ### Removed
-- **`BugBunny::SecurityError` eliminada (dead code):** la clase estaba definida y documentada como el control anti-RCE, pero **ninguna ruta de código la levantaba**. La protección real (clase enrutada debe heredar de `BugBunny::Controller`) ya existe en `Consumer` y responde **403 Forbidden** + reject + log `consumer.security_violation`, no una excepción. Un `rescue BugBunny::SecurityError` en un consumidor era código muerto (la excepción nunca se disparaba). Doc ajustada (`docs/errors/`, README, skill). — @Gabriel
+- **`BugBunny::SecurityError` eliminada:** introducida en `4f27bea` ("security controller") como la excepción prevista del control anti-RCE, pero **nunca se cableó** — ninguna ruta de código la levanta. La protección real (la clase enrutada debe heredar de `BugBunny::Controller`) vive en `Consumer` (`consumer.rb:222-228`) y responde **403 Forbidden** + reject + log `consumer.security_violation`, no una excepción. Eliminar la clase **no debilita** la protección (el guard 403 queda intacto). Doc ajustada (`docs/errors/`, README, skill). — @Gabriel
+
+  **Migración para consumidores:** quitar cualquier `rescue BugBunny::SecurityError`; el caso de controlador inválido llega como respuesta **403** en el envelope RPC (mapeable a `BugBunny::ClientError`/manejo de status), no como excepción local.
+
+  **Alcance verificado:** el grep que confirmó "nunca levantada" fue **in-repo** (lib + spec + test de esta gema). No se auditaron apps/gemas consumidoras externas — el bump MAJOR es la salvaguarda para ellas.
 
 ## [4.19.0] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,6 @@ BugBunny maps RabbitMQ responses to a semantic exception hierarchy, similar to h
 BugBunny::Error
 ├── CommunicationError                  (wraps any Bunny::Exception — TCP/auth/channel — at the gem boundary; .cause preserves the original)
 ├── ConfigurationError                  (invalid config attribute)
-├── SecurityError                       (unauthorized controller resolution)
 ├── PublishNacked                       (broker basic.nack on :confirmed publish)
 ├── PublishUnroutable                   (broker basic.return on mandatory + :confirmed)
 ├── ClientError (4xx)

--- a/docs/config/configuracion.md
+++ b/docs/config/configuracion.md
@@ -121,7 +121,7 @@ del código.
 | Health (`health_check_interval`/`health_check_file`) | observabilidad | `health_check_file` no escribible → el touch falla (degradación de visibilidad, no del flujo) | **escribe (touch) un archivo** en cada health check OK; `nil` desactiva | probe para orquestadores (K8s/Swarm) |
 | Callbacks (`on_return`/`on_rpc_reply`/`rpc_reply_headers`) | extensibilidad | una excepción en `on_return` se captura pero **degrada visibilidad** (YARD `configuration.rb:147`) | corren en hilos sensibles (ver §h) | propagar trace-context / alertar unroutable |
 | Confirms (`nack_raise`/`return_raise`) | integridad de entrega | `false` → NACK/return solo se logea, la llamada retorna `202` (modo legacy, posible pérdida silenciosa) | habilitan el raise de `PublishNacked`/`PublishUnroutable` | elegir entre fail-fast vs best-effort en publish confirmado |
-| Routing (`controller_namespace`) | seguridad | clase fuera del namespace/herencia → `SecurityError` (anti-RCE) | acota qué clases son enrutables | superficie de control de RCE |
+| Routing (`controller_namespace`) | seguridad | clase resuelta no subclase de `BugBunny::Controller` → el worker responde **403** + reject (guard anti-RCE, `consumer.rb:222-228`) | acota qué clases son enrutables | superficie de control de RCE |
 | Logging (`logger`/`bunny_logger`/`log_tags`) | observabilidad | — | salida a `$stdout` por default | trazabilidad estructurada |
 | Infra (`exchange_options`/`queue_options`) | infraestructura | options incompatibles con el broker → `PreconditionFailed` (vía `CommunicationError`) | defaults globales mergeados por recurso | declaración AMQP por default |
 

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -1,7 +1,7 @@
 # Errores — bug_bunny
 
 > meta: artefacto errores · RFC-020 · generado `arch-structure` (§a/§b/§d) +
-> `arch-enrich` (§c) · anclado a `5d7851a`, `lib/bug_bunny/exception.rb`,
+> `arch-enrich` (§c) · anclado a `d0533bf`, `lib/bug_bunny/exception.rb`,
 > `remote_error.rb`, `middleware/raise_error.rb`, `controller.rb`, `consumer.rb`
 > · fecha 2026-06-30 · cobertura: §a/§b/§d completas (estructura); §c política
 > completa (enrich, **inferida** de HTTP/AMQP — verificación humana pendiente).
@@ -26,7 +26,6 @@ Jerarquía (todas bajo `BugBunny::Error < ::StandardError`):
 └── BugBunny::Error                      base · attr_accessor :status, :raw_response (#52)
     ├── CommunicationError               fallo de red/conexión/protocolo AMQP
     ├── ConfigurationError               configuración inválida de la gema
-    ├── SecurityError                    acceso no permitido a controladores (anti-RCE)
     ├── PublishNacked                    broker NACK en publish :confirmed
     ├── PublishUnroutable                broker return (mandatory) sin binding
     ├── ClientError                      base 4xx
@@ -47,7 +46,6 @@ Jerarquía (todas bajo `BugBunny::Error < ::StandardError`):
 | `Error` | `::StandardError` | base — no se levanta directa salvo `resource.rb:122` (pool ausente) |
 | `CommunicationError` | `Error` | `bug_bunny.rb:96`, `session.rb:177,285`, `producer.rb:90`, `client.rb:168` — envuelve cualquier `Bunny::Exception` en la frontera del gem; original en `.cause` |
 | `ConfigurationError` | `Error` | `configuration.rb:262,269,277` — validación al final de `BugBunny.configure` |
-| `SecurityError` | `Error` | definida; sin raise-site localizado en `lib/` (ver §3) |
 | `PublishNacked` | `Error` | `producer.rb:235` — NACK del broker en modo `:confirmed`. Attrs: `path`, `nacked_count`. Opt-out `nack_raise: false` |
 | `PublishUnroutable` | `Error` | `producer.rb:325` — `basic.return` con `mandatory: true`. Attrs: `path`, `exchange`, `routing_key`, `reply_code`, `reply_text`, `correlation_id`. Opt-out `return_raise: false` |
 | `ClientError` | `Error` | `raise_error.rb:170` — 4xx no mapeado explícito |
@@ -86,6 +84,7 @@ operaciones de RFC-003 (`docs/api/`, hoy pendiente — ver §4), no las redefine
 | Cliente RPC | otro ≥400 | `ClientError` | 4xx no mapeado |
 | Productor (publish `:confirmed`) | n/a (AMQP) | `PublishNacked` / `PublishUnroutable` | NACK / return del broker — no es status HTTP |
 | Transporte (frontera gem) | n/a (AMQP) | `CommunicationError` | fallo de red/broker, envuelve `Bunny::Exception` |
+| **Worker (dispatch)** | **403** | — (no excepción; responde 403 + reject) | guard anti-RCE: clase enrutada no subclase de `BugBunny::Controller` (`consumer.rb:222-228`) |
 
 ### c. Política por error
 
@@ -96,7 +95,6 @@ HTTP (RFC 9110) + AMQP — verificación humana pendiente (ver §3).
 |---|---|---|---|---|
 | `CommunicationError` | sí (fallo transitorio de red/broker) | sí (`network_recovery_interval`; Bunny auto-recover) | el retry de un **publish** puede duplicar salvo consumidor idempotente; un **read** RPC es seguro | reintentar con backoff; si persiste, circuit-break y alertar |
 | `ConfigurationError` | **no** (bug de config) | — | n/a | fail-fast al boot; corregir el bloque `configure` |
-| `SecurityError` | **no** | — | n/a | rechazar; investigar (posible intento de RCE por clase no autorizada) |
 | `PublishNacked` | sí, con cautela (NACK puede ser transitorio: disk full, replicación) | sí | el re-publish puede duplicar → requiere dedup aguas abajo | reintentar acotado; si persiste, alertar (problema del broker) |
 | `PublishUnroutable` | **no** (no hay binding para la routing key) | — | n/a | corregir routing key / topología de bindings; alertar (mensaje perdido) |
 | `BadRequest` (400) | **no** | — | n/a | corregir el request del cliente |
@@ -163,11 +161,14 @@ parsea el body, devuelve `parsed['errors']` por convención o el cuerpo completo
 
 ## 3. Inferencias
 
-- **`SecurityError`** (`exception.rb:65`) está definida con docstring (anti-RCE,
-  valida herencia de clases enrutadas) pero **no se localizó su raise-site** en
-  `lib/` al commit `5d7851a`. `confidence: low` — puede levantarse en una capa de
-  routing no cubierta por el grep, ser aspiracional, o levantarse por el host. A
-  verificar con el dueño del código.
+- **Guard anti-RCE = 403, no excepción.** El control de seguridad que valida la
+  herencia de la clase enrutada vive en `consumer.rb:222-228`: si la clase
+  resuelta no es subclase de `BugBunny::Controller`, el worker loguea
+  `consumer.security_violation`, responde **403 'Forbidden'** (`handle_fatal_error`)
+  y rechaza el mensaje sin requeue — **no levanta una excepción dedicada**. La ex
+  `BugBunny::SecurityError` (nunca levantada en ninguna ruta de código) fue
+  **eliminada como dead code**; el contrato real del unhappy path de RCE es el 403
+  (ver §b). `confidence: high` (verificado por grep exhaustivo + lectura del guard).
 - **§b superficies AMQP** (`PublishNacked`/`PublishUnroutable`/`CommunicationError`)
   no tienen status HTTP: son señales del protocolo AMQP, no del envelope RPC. Se
   listan como `n/a (AMQP)` para no forzar un código HTTP inventado.

--- a/lib/bug_bunny/exception.rb
+++ b/lib/bug_bunny/exception.rb
@@ -60,10 +60,6 @@ module BugBunny
   # Se levanta al final de {BugBunny.configure} si algún atributo no pasa las validaciones.
   class ConfigurationError < Error; end
 
-  # Error lanzado cuando ocurren un acceso no permitido a controladores.
-  # Protege contra vulnerabilidades de RCE validando la herencia de las clases enrutadas.
-  class SecurityError < Error; end
-
   # Error lanzado cuando el broker responde NACK a una publicación en modo `:confirmed`.
   #
   # Un NACK significa que el broker rechazó explícitamente el mensaje (ej: política de

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -415,8 +415,9 @@ Limitación de RSpec: `instance_double` valida que el método exista pero **no**
 **Causa:** No hubo respuesta en `config.rpc_timeout` segundos.
 **Resolución:** Verificar que el worker esté activo y que el controlador remoto no lance excepciones silenciosas.
 
-### BugBunny::SecurityError
+### Guard anti-RCE (403, no es excepción)
 **Causa:** El mensaje intenta ejecutar un controlador que no hereda de `BugBunny::Controller`.
+**Comportamiento:** El worker responde **403 Forbidden** + reject + log `event=consumer.security_violation` (`consumer.rb:222-228`); no levanta una excepción dedicada.
 **Resolución:** Verificar la jerarquía de controladores y que `config.controller_namespace` coincida.
 
 ### BugBunny::RouteNotFoundError (404)

--- a/skill/references/consumer.md
+++ b/skill/references/consumer.md
@@ -119,5 +119,5 @@ livenessProbe:
 |-----------|-----------|
 | Ruta no encontrada | 404 + log `event=consumer.route_not_found` |
 | Controller no encontrado (namespace) | 404 + log `event=consumer.controller_not_found` |
-| Controller no hereda de BugBunny::Controller | `SecurityError` |
+| Controller no hereda de BugBunny::Controller | 403 Forbidden + reject + log `event=consumer.security_violation` (guard anti-RCE) |
 | Excepción no capturada en controller | 500 + log `event=controller.unhandled_exception` con backtrace |

--- a/skill/references/errores.md
+++ b/skill/references/errores.md
@@ -7,7 +7,6 @@ StandardError
 └── BugBunny::Error
     ├── BugBunny::CommunicationError
     ├── BugBunny::ConfigurationError
-    ├── BugBunny::SecurityError
     ├── BugBunny::PublishNacked
     ├── BugBunny::PublishUnroutable
     ├── BugBunny::ClientError (4xx)
@@ -58,9 +57,10 @@ message, details } }`), parsealo en el boundary del servicio desde
 **Validaciones:** host (String no vacío), port (1-65535), username/password (no nil), heartbeat (0-3600), rpc_timeout (>0), channel_prefetch (1-10000).
 **Resolución:** Revisar el bloque `BugBunny.configure` y corregir valores.
 
-### BugBunny::SecurityError
+### Guard anti-RCE (403, no es excepción)
 **Causa:** Un mensaje intenta ejecutar un controlador que no hereda de `BugBunny::Controller`.
-**Cuándo:** El consumer resuelve la clase pero falla la validación `is_a?(BugBunny::Controller)`.
+**Cuándo:** El consumer resuelve la clase (`constantize`) pero falla `controller_class < BugBunny::Controller` (`consumer.rb:222-228`).
+**Comportamiento:** El worker **no levanta una excepción** — loguea `event=consumer.security_violation`, responde **403 Forbidden** al caller RPC y rechaza el mensaje sin requeue.
 **Resolución:** Verificar que el controlador herede de `BugBunny::Controller` y que `config.controller_namespace` sea correcto.
 
 ### BugBunny::PublishNacked

--- a/skill/references/routing.md
+++ b/skill/references/routing.md
@@ -69,7 +69,7 @@ El consumer resuelve el controlador concatenando:
 
 Ejemplo: namespace `:admin`, controller `:reports` → `BugBunny::Controllers::Admin::ReportsController`
 
-Valida que el controlador sea subclase de `BugBunny::Controller`. Si no, lanza `SecurityError`.
+Valida que el controlador sea subclase de `BugBunny::Controller` (guard anti-RCE). Si no, el worker loguea `consumer.security_violation`, responde **403 Forbidden** y rechaza el mensaje sin requeue (`consumer.rb:222-228`) — no levanta una excepción dedicada.
 
 ## Route Object
 


### PR DESCRIPTION
## Hallazgo

Se pidió verificar dónde se levanta `BugBunny::SecurityError`. Resultado: **en ningún lado**. `grep` in-repo (lib + spec + test) encuentra solo el `class def`; cero `raise`/`fail`. Era **dead code** — introducida en `4f27bea` ("security controller") como la excepción prevista del guard anti-RCE, pero **nunca cableada**.

La protección anti-RCE real vive en `Consumer#process_message` (`consumer.rb:222-228`): valida que la clase enrutada herede de `BugBunny::Controller`; si no, loguea `consumer.security_violation`, responde **403 Forbidden** y rechaza el mensaje sin requeue. Eliminar la clase **no debilita** la protección.

## Cambio (opción 2: eliminar + ajustar doc)

- **`lib/bug_bunny/exception.rb`:** removida la clase `SecurityError`.
- **`docs/errors/errors.md`:** fuera de §a (árbol + tabla) y §c; §3 documenta el guard 403 (`confidence: high`); §b suma fila `Worker · 403`.
- **`docs/config/configuracion.md` §f:** fila Routing → 403.
- **`AGENTS.md`, `README.md`:** refs actualizadas.
- **`skill/SKILL.md` + `references/{errores,consumer,routing}.md`:** corregidas — `routing.md` y `consumer.md` afirmaban **falsamente** que se lanzaba; ahora describen el 403.
- **`CHANGELOG.md`:** entrada `[Unreleased]`.

## 🔴 Versionado: requiere bump MAJOR

Corregido tras la síntesis multi-vendor (opencode + agy): **es breaking real, no inerte**. Aunque la excepción nunca se *levantaba*, un `rescue BugBunny::SecurityError` en un consumidor resuelve la constante cuando *cualquier* excepción entra a ese bloque → `NameError` que enmascara la excepción original. Por eso:
- **Bump MAJOR forzoso** al `/gem-release` (no decisión diferida).
- **Migración:** quitar cualquier `rescue BugBunny::SecurityError`; el controlador inválido llega como **403** en el envelope, no como excepción local.
- **Alcance del grep:** in-repo. Apps/gemas consumidoras externas no auditadas → el bump MAJOR es la salvaguarda.

## Verificación
- `rubocop` clean · `rake spec:unit` → **236 examples, 0 failures** · 0 referencias colgantes · critias `--pr --full`: 0 err / 0 warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)